### PR TITLE
Support VirtualBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
 ---
 
 ### Booting into LensorOS on hardware <a name="hardware-boot"></a>
-###### DISCLAIMER: LensorOS IS IN NO WAY GUARANTEED TO BE 'SAFE'; RUN AT YOUR OWN RISK! (see LICENSE)
+###### DISCLAIMER: LensorOS IS IN NO WAY GUARANTEED TO BE 'SAFE'; RUN AT YOUR OWN RISK! (see [LICENSE](LICENSE))
 
 (pre-compiled binaries coming soon, for now see [the build section](#build))
 
 Ensure you have a USB storage device that is working. Remove all data from the USB. This can be done by formatting, or simply deleting/moving everything off of it.
 
-Next, create a folder called `efi`, then inside that a folder called `boot`. \
-Move `main.efi` from `/gnu-efi/x86_64/bootloader/` directory into the `boot` folder on the USB. \
-Rename `main.efi` in the usb's `boot` folder to `bootx64.efi`.
+Next, create a folder called `EFI`, then inside that a folder called `BOOT`. \
+Move `main.efi` from `/gnu-efi/x86_64/bootloader/` directory into the `BOOT` folder on the USB. \
+Rename `main.efi` in the usb's `BOOT` folder to `bootx64.efi`, as per the UEFI specification.
 
-Finally, navigate back to the root directory of the USB (where the `efi` folder resides). \
+Finally, navigate back to the root directory of the USB (where the `EFI` folder resides). \
 Create a folder. `LensorOS`, then move the following resources into the directory: \
 - `kernel.elf` from `/kernel/bin/`
 - Any `.psf` version 1 font renamed to `dfltfont.psf`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ### Table of Contents
 - [Booting into LensorOS on hardware](#hardware-boot)
 - [Booting into LensorOS using QEMU](#qemu-boot)
+- [Booting into LensorOS using VirtualBox](#vbox-boot)
 - [Building LensorOS](#build)
   - [A bug regarding CMake's ASM_NASM Makefile generation](#cmake-bug)
 - [Acknowledgements](#ack)
@@ -51,53 +52,107 @@ USB
 ---
 
 ### Booting into LensorOS using QEMU <a name="qemu-boot"></a>
+[Get QEMU](https://www.qemu.org/download)
+
+Before beginning, ensure you have the LensorOS bootloader and kernel binaries. \
 (pre-compiled binaries coming soon, for now see [the build section](#build))
 
 To change the font, replace `dfltfont.psf` in the `kernel/res` folder with any PSF1 font (not PSF2). \
 For a few fonts that are compatible, check out [this repository](https://github.com/ercanersoy/PSF-Fonts)
 
-NOTE: If using VirtualBox, you will need to use the following QEMU tool to create a bootable virtual disk (`.vdi`):
-`qemu-img convert -f raw -O vdi LensorOS/kernel/bin/LensorOS.img path/to/LensorOS.vdi`, but be warned: there be dragons.
+NOTE: On Windows, use a linux terminal to run the image generation commands (WSL, Cygwin, etc).
 
-#### On Linux
-
-First, `cd` to the `kernel` directory of the repository.
-
-The first time after cloning, the line endings will not be in the correct format. \
-This is a choice by git, that all files will be saved with CRLF line endings, and unix bash doesn't play nice with that. \
-To get around that, there are a multitude of tools to convert, but by far the most common is `dos2unix`:
+Ensure the following dependencies are installed on your system:
 ```bash
-dos2unix mkimg.sh
-dos2unix run.sh
-dos2unix rundbg.sh
+sudo apt install mtools
+```
+GNU mtools is a set of tools for manipulating MS-DOS style files and filesystems. This is necessary as the UEFI specification requires FAT32 to be used as it's boot device's filesystem.
+
+To build a disk image that will boot into LensorOS, run the following included helper script:
+```bash
+bash /Path/to/LensorOS/kernel/mkimg.sh
 ```
 
-From there, `bash mkimg.sh` will generate a `.img` disk image file that can be used as a boot drive by a virtual machine that supports OVMF like [QEMU](https://www.qemu.org/).
+Upon completion, this will have generated a disk image file `LensorOS.img` that follows the UEFI standards, meaning any UEFI-supporting machine could boot from this image, given it is a valid boot device.
 
-`bash run.sh` will boot up QEMU into LensorOS. \
-QEMU does need to be installed, so make sure you first run (`sudo apt install qemu-system-x86`).
+- [Continue on Linux](#qemu-boot-linux)
+- [Continue on Windows](#qemu-boot-windows)
 
+#### On Linux <a name="qemu-boot-linux"></a>
+To run QEMU with the correct command line options automatically, use the following helper script to launch QEMU booting into LensorOS:
+```bash
+bash /Path/to/LensorOS/kernel/run.sh
+```
+For debugging with gdb, run `bash rundbg.sh` instead. This will launch QEMU but wait to start cpu execution until `gdb` has connected on port `1234` of `localhost`. \
 See [a note about debugging](#gdb-debug-note-1).
 
-For debugging with gdb, run `bash rundbg.sh` instead. This will launch QEMU but wait to start cpu execution until `gdb` has connected on port `1234` of `localhost`.
-
-#### On Windows
-
-In a linux terminal (WSL, Cygwin, etc), run `bash /path/to/LensorOS/kernel/mkimg.sh` to generate a disk image file that will be used by QEMU as a boot drive.
-
+#### On Windows <a name="qemu-boot-windows"></a>
 To launch QEMU from the generated disk image, A `run.bat` file is included. \
-By simply double clicking this, QEMU will run, booting into a UEFI environment that will load the LensorOS bootloader. The batch file requires the directory that the QEMU executable resides in be added to the system's PATH variable. [See this stackoverflow thread for help](https://stackoverflow.com/questions/9546324/adding-a-directory-to-the-path-environment-variable-in-windows). \
-If editing the PATH variable isn't working, the batch script could always be edited to use the exact path to the QEMU executable on your local machine.
+The batch file requires the directory that the QEMU executable resides in be added to the system's PATH variable. [See this stackoverflow thread for help](https://stackoverflow.com/questions/9546324/adding-a-directory-to-the-path-environment-variable-in-windows). \
+If editing the PATH variable isn't working, the batch script could always be edited to use the exact path to the QEMU executable on your local machine. \
 
-If you're terminal output looks rather mangled (ie. left-pointing arrows, open square-brackets, etc), it is likely the terminal you are using doesn't support ANSI color codes. \
-This is how it is when I use Windows Explorer to launch the `run` batch script, and makes debugging using the serial output rather difficult. \
-To get around this, I use the (rather life-changing) [Windows Terminal](https://github.com/Microsoft/Terminal). It should be the default terminal, and should have been for five years now, but I'm glad it is available and open source none-the-less. \
-This new terminal allows both WSL and PowerShell to be open in the same terminal, but separate tabs. By running `& '\\wsl$\your-linux-distro\path\to\LensorOS\kernel\run.bat'` from within a PowerShell in the new Windows Terminal, you will experience glorious full-color, formatted serial output. If you are having none of this, and would prefer to have a very monotone serial output that is also not mangled with ANSI color codes, define `LENSOR_OS_UART_HIDE_COLOR_CODES` and all color codes will be hidden from serial output.
+By simply double clicking this batch file, QEMU will open and boot into LensorOS. 
 
-There is also a `rundbg.bat` that will launch QEMU with the appropriate flags to wait for `gdb` to connect on port `1234` of `localhost`.
+All serial output will be re-directed to stdin/stdout, which is likely a `cmd.exe` window that opened along with QEMU. The problem with `cmd.exe` is that it leaves the output looking rather mangled (ie. left-pointing arrows, open square-brackets, etc). This is due to the terminal not supporting ANSI color codes.
 
-<a name="gdb-debug-note-1"></a>NOTE: When debugging with gdb, the kernel must be built with debug symbols ("-g" compile flag). To achieve this, run cmake with the following definition: \
+To get around this, I use the (rather life-changing) [Windows Terminal](https://github.com/Microsoft/Terminal). It should be the default terminal, and should have been for five years now, but I'm glad it is available and open source none-the-less.
+
+This new terminal allows both WSL and PowerShell to be open in the same terminal, but separate tabs. By the `run.bat` file from within a PowerShell in the new Windows Terminal, you will experience glorious full-color, formatted serial output.
+
+If you are having none of this, and would prefer to have a very monotone serial output that is also not mangled with ANSI color codes, define `LENSOR_OS_UART_HIDE_COLOR_CODES` during compilation and all color codes will be hidden from serial output by the kernel itself.
+
+There is also a `rundbg.bat` that will launch QEMU with the appropriate flags to wait for `gdb` to connect on port `1234` of `localhost`. \
+<a name="gdb-debug-note-1"></a>NOTE: When debugging with gdb, the kernel must be built with debug symbols ("-g" compile flag). To achieve this, run cmake with the following command line argument: \
 `-DCMAKE_BUILD_TYPE=Debug`
+
+---
+
+### Booting into LensorOS using VirtualBox <a name="vbox-boot"></a>
+[Get VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+
+VirtualBox is kind of picky in the file formats it will accept as drives and such. \
+Because of this fact, we must prepare an `.iso` file with an ISO filesystem to boot into VirtualBox.
+
+Before beginning, ensure you have the LensorOS bootloader and kernel binaries built. \
+(pre-compiled binaries coming soon, for now see [the build section](#build))
+
+To change the font, replace `dfltfont.psf` in the `kernel/res` folder with any PSF1 font (not PSF2). \
+For a few fonts that are compatible, check out [this repository](https://github.com/ercanersoy/PSF-Fonts)
+
+NOTE: On Windows, complete the following shell commands from within WSL, or the Windows Subsystem for Linux.
+
+Install the tool necessary to create `.iso` files and ISO-9660 filesystems, as well as a tool to create and format MS-DOS style filesystems:
+```bash
+sudo apt install mtools xorriso
+```
+Next, simply run the `mkiso.sh` script with Bash:
+```bash
+bash /Path/to/LensorOS/kernel/mkiso.sh
+```
+
+If all goes well, this will first generate a FAT32 EFI-compatible boot disk image, then create a bootable ISO-9660 CD-ROM disk image. \
+To actually use this boot cd in a VM in VirtualBox, it requires some setup:
+1. Open VirtualBox.
+2. Click the `New` button.
+3. Give the VM a name and a file path you are comfortable with.
+4. Select Type of `Other` and Version of `Other/Unknown (64-bit)`.
+5. Leave the memory size how it is; 64MB is plenty at this time.
+6. Select the `Do not add a virtual hard disk` option.
+7. Click the `Create` button to create the new virtual machine.
+8. With the new VM selected within the list on the left, click the `Settings` button.
+9. Navigate to `System` within the list on the left.
+    1. Change Chipset to `ICH9`.
+    2. Enable Extended Feature `Enable EFI (special OSes only)`.
+    3. Navigate to the `Processor` tab, and check the `Enable Nested VT-x/AMD-V` checkbox.
+10. Navigate to `Storage` within the list on the left.
+    1. Right click the storage controller (default IDE), and select `Optical Drive`.
+    2. Click the `Add` button in the new `Optical Disk Selector` window that pops up.
+    3. Browse to `Path/To/LensorOS/kernel/bin/` and select `LensorOS.iso`.
+    4. Ensure `LensorOS.iso` is selected within the list, and click the `Choose` button.
+11. Navigate to `Network` within the list on the left.
+    1. Disable all network adapters.
+
+After all of this has been done, you are ready to click `Start` on the VirtualBox VM; the bootloader should run automatically.
 
 ---
 
@@ -146,7 +201,7 @@ Once the toolchain is up and running (added to `$PATH` and everything), continue
 NOTE: It is possible to use your host compiler to build the kernel. It is not recommended, and likely won't work, but who am I to stop you. Simply remove/comment out the `set(CMAKE_C_COMPILER` and `set(CMAKE_CXX_COMPILER` lines within [CMakeLists.txt](kernel/CMakeLists.txt). This will instruct CMake to use your host machine's default compiler (again, **not** recommended).
 
 First, `cd` to the `kernel` directory of the repository. \
-To prepare a build system that will build the kernel with GNU `make`, run the following:
+To prepare a build system that will build the kernel with `GNU make`, run the following:
 ```bash
 cmake -S . -B out
 cd out
@@ -159,8 +214,8 @@ Alternatively, generate any build system of your choice that is supported by CMa
 
 This final build step will generate `kernel.elf` within the `/kernel/bin` directory, ready to be used in a boot usb or formatted into an image.
 
-If building for real hardware, ensure to remove `-DQEMU` from [CMakeLists.txt](kernel/CMakeLists.txt). \
-This allows for the hardware timers to be used to their full potential (asking QEMU for 1000hz interrupts from multiple devices overloads the emulator and guest time falls behind drastically; to counter-act this, very slow frequency periodic interrupts are setup as to allow the emulator to process them accordingly, allowing for accurate time-keeping even in QEMU).
+If building for real hardware, ensure to remove all virtual machine definitions (ie. `QEMU`, `VBOX`) from [CMakeLists.txt](kernel/CMakeLists.txt). \
+This allows for the hardware timers to be used to their full potential (asking QEMU for 1000hz interrupts from multiple devices overloads the emulator and guest time falls behind drastically; to counter-act this, very slow frequency periodic interrupts are setup as to allow the emulator to process them accordingly, allowing for accurate time-keeping in QEMU).
 
 If you are familiar with CMake, this sequence might look *slightly* strange to you (namely the second `cmake` command). \
 See the [CMake bug](#cmake-bug) section for more details on why it is needed, and maybe you have an even better fix.

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -129,9 +129,10 @@ SOURCES
 add_executable(Kernel ${SOURCES} ${HEADERS})
 set_target_properties(Kernel PROPERTIES OUTPUT_NAME kernel.elf)
 
+# VIRTUAL MACHINE CONFIGURATION
 # Uncomment the line that corresponds to the virtual machine
 #   of your choosing, ensuring only one is defined at one time.
-# target_compile_definitions(Kernel PUBLIC QEMU)
+#target_compile_definitions(Kernel PUBLIC QEMU)
 target_compile_definitions(Kernel PUBLIC VBOX)
 
 target_compile_options(

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -129,7 +129,11 @@ SOURCES
 add_executable(Kernel ${SOURCES} ${HEADERS})
 set_target_properties(Kernel PROPERTIES OUTPUT_NAME kernel.elf)
 
-target_compile_definitions(Kernel PUBLIC QEMU)
+# Uncomment the line that corresponds to the virtual machine
+#   of your choosing, ensuring only one is defined at one time.
+# target_compile_definitions(Kernel PUBLIC QEMU)
+target_compile_definitions(Kernel PUBLIC VBOX)
+
 target_compile_options(
 Kernel PUBLIC
     -O4

--- a/kernel/mkiso.sh
+++ b/kernel/mkiso.sh
@@ -1,0 +1,6 @@
+ScriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$ScriptDirectory/mkimg.sh
+mkdir -p iso
+cp $ScriptDirectory/bin/LensorOS.img iso
+xorriso -as mkisofs -R -f -e LensorOS.img -no-emul-boot -o $ScriptDirectory/bin/LensorOS.iso iso
+rm -r iso

--- a/kernel/src/ahci.cpp
+++ b/kernel/src/ahci.cpp
@@ -181,27 +181,28 @@ namespace AHCI {
     }
 
     AHCIDriver::AHCIDriver(PCI::PCIDeviceHeader* pciBaseAddress) {
-        UART::out("[AHCI]: Constructing driver for AHCI 1.0 Controller at 0x");
+        UART::out("\r\n[AHCI]: Constructing driver for AHCI 1.0 Controller at 0x");
         UART::out(to_hexstring(pciBaseAddress));
         UART::out("\r\n");
         
         PCIBaseAddress = pciBaseAddress;
-        
+        // ABAR = AHCI Base Address Register.
         ABAR = (HBAMemory*)(u64)(((PCI::PCIHeader0*)PCIBaseAddress)->BAR5);
         // Map ABAR into memory.
         Memory::map(ABAR, ABAR);
 
         UART::out("[AHCI]:\r\n  Mapping AHCI Base Memory Register (ABAR) to 0x");
         UART::out(to_hexstring(ABAR));
-        UART::out("\r\n");
-        UART::out("  Probing ABAR for open and active ports.\r\n");
+        UART::out("\r\n  Probing ABAR for open and active ports.\r\n");
+
         probe_ports();
+
         UART::out("  Found ");
-        UART::out(to_string(numPorts));
+        UART::out(numPorts);
         UART::out(" open and active ports\r\n");
         UART::out("    Port read/write buffer size: ");
         UART::out(to_string(MAX_READ_PAGES * 4));
-        UART::out("kib\r\n");
+        UART::out("kib\r\n\r\n");
 
         for (u8 i = 0; i < numPorts; ++i) {
             Ports[i]->initialize();
@@ -261,7 +262,7 @@ namespace AHCI {
                     }
                     UART::out("  Total Size: ");
                     UART::out(to_string(fs->get_total_size() / 1024 / 1024));
-                    UART::out(" mib\r\n");
+                    UART::out(" mib\r\n\r\n");
                 }
                 else {
                     UART::out("[AHCI]: \033[31mDevice at port ");
@@ -270,7 +271,7 @@ namespace AHCI {
                 }
             }
         }
-        UART::out("[AHCI]: \033[32mDriver constructed.\033[0m\r\n");
+        UART::out("[AHCI]: \033[32mDriver constructed.\033[0m\r\n\r\n");
     }
     
     AHCIDriver::~AHCIDriver() {

--- a/kernel/src/cpu.h
+++ b/kernel/src/cpu.h
@@ -124,10 +124,11 @@ public:
         UART::out(to_string(XSAVEEnabled));
         UART::out("\r\n    AVX: ");
         UART::out(to_string(AVXEnabled));
-        UART::out("\r\n");
+        UART::out("\r\n\r\n");
         CPUs.for_each([](auto* it){
             it->value().print_debug();
         });
+        UART::out("\r\n");
     }
 
     // Feature flag setters

--- a/kernel/src/fat_driver.cpp
+++ b/kernel/src/fat_driver.cpp
@@ -157,6 +157,7 @@ void FATDriver::read_directory
         if (port->read(firstSectorOfCluster, BR->BPB.NumSectorsPerCluster, clusterContents.get(), clusterSizeInBytes) == false) {
             for (u32 i = 0; i < indentLevel + 1; ++i)
                 UART::out(indent);
+
             UART::out("\033[31mCluster read failed.\033[0m\r\n");
             return;
         }
@@ -189,6 +190,7 @@ void FATDriver::read_directory
             bool is_file = false;
             for (u32 i = 0; i < indentLevel + 1; ++i)
                 UART::out(indent);
+
             if (current->Attributes & FAT_ATTR_READ_ONLY)
                 UART::out("Read-only ");
             if (current->Attributes & FAT_ATTR_HIDDEN)
@@ -226,6 +228,7 @@ void FATDriver::read_directory
                 // Print file size.
                 for (u32 i = 0; i < indentLevel + 3; ++i)
                     UART::out(indent);
+
                 UART::out("File Size: ");
                 UART::out(to_string(current->FileSizeInBytes / 1024 / 1024));
                 UART::out(" MiB (");
@@ -344,4 +347,5 @@ void FATDriver::read_root_directory(AHCI::Port* port, BootRecord* BR, FATType ty
     UART::out("[FATDriver]:\r\n");
     u32 clusterIndex = get_root_directory_cluster(BR, type);
     read_directory(port, BR, type, clusterIndex);
+    UART::out("\r\n");
 }

--- a/kernel/src/hpet.cpp
+++ b/kernel/src/hpet.cpp
@@ -54,15 +54,24 @@ bool HPET::initialize() {
      */
     LargeCounterSupport = static_cast<bool>(readl(HPET_REG_GENERAL_CAPABILITIES_AND_ID) & (1 << 13));
 
+    UART::out("[HPET]: After first read\r\n");
+
     /* If bit 15 of general cap. & ID register is set, HPET is 
      *   capable of legacy replacement interrupt mapping (IRQ0, IRQ8).
      */
     LegacyInterruptSupport = static_cast<bool>(readl(HPET_REG_GENERAL_CAPABILITIES_AND_ID) & (1 << 15));
 
+    UART::out("[HPET]: After second read\r\n");
+
     // Disable legacy replacement interrupt routing.
     u32 config = readl(HPET_REG_GENERAL_CONFIGURATION);
     config &= ~2;
+
+    UART::out("[HPET]: After config read\r\n");
+
     writel(HPET_REG_GENERAL_CONFIGURATION, config);
+
+    UART::out("[HPET]: Wrote config\r\n");
 
     // Calculate Frequency (f = 10^15 / Period)
     Period = readl(HPET_MAIN_COUNTER_PERIOD);

--- a/kernel/src/interrupts/idt.cpp
+++ b/kernel/src/interrupts/idt.cpp
@@ -1,4 +1,6 @@
 #include "idt.h"
+
+#include "../integers.h"
 #include "../memory.h"
 
 IDTR gIDT;

--- a/kernel/src/interrupts/interrupts.cpp
+++ b/kernel/src/interrupts/interrupts.cpp
@@ -112,7 +112,7 @@ void mouse_handler(InterruptFrame* frame) {
     end_of_interrupt(12);
 }
 
-// FAULT INTERRUPT HANDLERS
+/// FAULT INTERRUPT HANDLERS
 
 __attribute__((interrupt))
 void divide_by_zero_handler(InterruptFrame* frame) {

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -94,6 +94,9 @@ CPUDescription* SystemCPU { nullptr };
 u8 fxsave_region[512] __attribute__((aligned(16)));
 
 void kernel_init(BootInfo* bInfo) {
+
+    (void)bInfo;
+    
     /* 
      *   - Prepare physical/virtual memory
      *     - Initialize Physical Memory Manager
@@ -123,78 +126,78 @@ void kernel_init(BootInfo* bInfo) {
     asm ("cli");
 
     // Setup serial communications chip.
-    UART::initialize();
-    UART::out("\r\n!===--- You are now booting into \033[1;33mLensorOS\033[0m ---===!\r\n\r\n");
+    ////UART::initialize();
+    ////UART::out("\r\n!===--- You are now booting into \033[1;33mLensorOS\033[0m ---===!\r\n\r\n");
     // Parse memory map passed by bootloader.
     // Setup dynamic memory allocation.
     // Setup memory state from EFI memory map.
-    Memory::init_physical_efi(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
+    ////Memory::init_physical_efi(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
     // Setup virtual to physical memory mapping.
-    Memory::init_virtual();
+    ////Memory::init_virtual();
     // Setup dynamic memory allocation (`new`, `delete`).
-    init_heap();
+    ////init_heap();
 
     // Prepare Global Descriptor Table Descriptor.
     GDTDescriptor GDTD = GDTDescriptor(sizeof(GDT) - 1, (u64)&gGDT);
     LoadGDT(&GDTD);
     // Prepare Interrupt Descriptor Table.
-    prepare_interrupts();
+    ////prepare_interrupts();
 
     // Setup random number generators.
-    gRandomLCG = LCG();
-    gRandomLFSR = LFSR();
+    ////gRandomLCG = LCG();
+    ////gRandomLFSR = LFSR();
 
-    // Create basic framebuffer renderer.
-    UART::out("[kUtil]: Setting up Graphics Output Protocol Renderer\r\n");
-    gRend = BasicRenderer(bInfo->framebuffer, bInfo->font);
-    UART::out("  \033[32mSetup Successful\033[0m\r\n");
-    draw_boot_gfx();
-    // Create basic text renderer for the keyboard.
-    Keyboard::gText = Keyboard::BasicTextRenderer();
+    ////// Create basic framebuffer renderer.
+    ////UART::out("[kUtil]: Setting up Graphics Output Protocol Renderer\r\n");
+    ////gRend = BasicRenderer(bInfo->framebuffer, bInfo->font);
+    ////UART::out("  \033[32mSetup Successful\033[0m\r\n");
+    ////draw_boot_gfx();
+    ////// Create basic text renderer for the keyboard.
+    ////Keyboard::gText = Keyboard::BasicTextRenderer();
 
-    // Initialize the Programmable Interval Timer.
-    gPIT = PIT();
-    UART::out("[kUtil]: \033[32mProgrammable Interval Timer Initialized\033[0m\r\n");
-    UART::out("  Channel 0, H/L Bit Access\r\n");
-    UART::out("  Rate Generator, BCD Disabled\r\n");
-    UART::out("  Periodic interrupts at \033[33m");
-    UART::out(to_string(PIT_FREQUENCY));
-    UART::out("hz\033[0m.\r\n");
-    // Initialize the Real Time Clock.
-    gRTC = RTC();
-    gRTC.set_periodic_int_enabled(true);
-    UART::out("[kUtil]: \033[32mReal Time Clock Initialized\033[0m\r\n");
-    UART::out("  Periodic interrupts enabled at \033[33m");
-    UART::out(to_string((double)RTC_PERIODIC_HERTZ));
-    UART::out("hz\033[0m\r\n");
+    ////// Initialize the Programmable Interval Timer.
+    ////gPIT = PIT();
+    ////UART::out("[kUtil]: \033[32mProgrammable Interval Timer Initialized\033[0m\r\n");
+    ////UART::out("  Channel 0, H/L Bit Access\r\n");
+    ////UART::out("  Rate Generator, BCD Disabled\r\n");
+    ////UART::out("  Periodic interrupts at \033[33m");
+    ////UART::out(to_string(PIT_FREQUENCY));
+    ////UART::out("hz\033[0m.\r\n");
+    ////// Initialize the Real Time Clock.
+    ////gRTC = RTC();
+    ////gRTC.set_periodic_int_enabled(true);
+    ////UART::out("[kUtil]: \033[32mReal Time Clock Initialized\033[0m\r\n");
+    ////UART::out("  Periodic interrupts enabled at \033[33m");
+    ////UART::out(to_string((double)RTC_PERIODIC_HERTZ));
+    ////UART::out("hz\033[0m\r\n");
     
     // Print real time to serial output.
-    UART::out("[kUtil]: \033[1;33mNow is ");
-    UART::out(to_string(gRTC.Time.hour));
-    UART::outc(':');
-    UART::out(to_string(gRTC.Time.minute));
-    UART::outc(':');
-    UART::out(to_string(gRTC.Time.second));
-    UART::out(" on ");
-    UART::out(to_string(gRTC.Time.year));
-    UART::outc('-');
-    UART::out(to_string(gRTC.Time.month));
-    UART::outc('-');
-    UART::out(to_string(gRTC.Time.date));
-    UART::out("\033[0m\r\n");
+    ////UART::out("[kUtil]: \033[1;33mNow is ");
+    ////UART::out(to_string(gRTC.Time.hour));
+    ////UART::outc(':');
+    ////UART::out(to_string(gRTC.Time.minute));
+    ////UART::outc(':');
+    ////UART::out(to_string(gRTC.Time.second));
+    ////UART::out(" on ");
+    ////UART::out(to_string(gRTC.Time.year));
+    ////UART::outc('-');
+    ////UART::out(to_string(gRTC.Time.month));
+    ////UART::outc('-');
+    ////UART::out(to_string(gRTC.Time.date));
+    ////UART::out("\033[0m\r\n");
 
     // Store feature set of CPU (capabilities).
-    SystemCPU = new CPUDescription();
+    ////SystemCPU = new CPUDescription();
     // Check for CPUID availability ('ID' bit in rflags register modifiable)
-    bool supportCPUID = static_cast<bool>(cpuid_support());
-    if (supportCPUID) {
-        SystemCPU->set_cpuid_capable();
-        UART::out("[kUtil]: \033[32mCPUID is supported\033[0m\r\n");
-        char* cpuVendorID = cpuid_string(0);
-        SystemCPU->set_vendor_id(cpuVendorID);
-        UART::out("  CPU Vendor ID: ");
-        UART::out((u8*)SystemCPU->get_vendor_id(), 12);
-        UART::out("\r\n");
+    ////bool supportCPUID = static_cast<bool>(cpuid_support());
+    ////if (supportCPUID) {
+        ////SystemCPU->set_cpuid_capable();
+        ////UART::out("[kUtil]: \033[32mCPUID is supported\033[0m\r\n");
+        ////char* cpuVendorID = cpuid_string(0);
+        ////SystemCPU->set_vendor_id(cpuVendorID);
+        ////UART::out("  CPU Vendor ID: ");
+        ////UART::out((u8*)SystemCPU->get_vendor_id(), 12);
+        ////UART::out("\r\n");
         /* Current functionality of giant `if` statemnt:
          * |- Setup FXSAVE/FXRSTOR
          * |  |- Setup FPU
@@ -208,138 +211,139 @@ void kernel_init(BootInfo* bInfo) {
          *   https://wiki.osdev.org/Detecting_CPU_Topology_(80x86)#Using_CPUID
          */
 
-        CPUIDRegisters regs;
-        cpuid(1, regs);
+    //     CPUIDRegisters regs;
+    //     cpuid(1, regs);
 
-        // Enable FXSAVE/FXRSTOR instructions if CPU supports it.
-        // If it is not supported, don't bother trying to support FPU, SSE, etc
-        //   as there would be no mechanism to save/load the registers on context switch.
-        // TODO: Get logical/physical core bits from CPUID
-        // |- 0x0000000b -- Intel
-        // |- 0x80000008 -- AMD
-        // `- Otherwise: bits are zero, assume single core.
-        // TODO: Rewrite task switching code to save/load all supported registers in CPUState.
-        if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FXSR)) {
-            SystemCPU->set_fxsr_capable();
-            asm volatile ("fxsave %0" :: "m"(fxsave_region));
-            UART::out("  \033[32mFXSAVE/FXRSTOR Enabled\033[0m\r\n");
-            SystemCPU->set_fxsr_enabled();
-            // If FXSAVE/FXRSTOR is supported, setup FPU.
-            if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FPU)) {
-                SystemCPU->set_fpu_capable();
-                // FPU supported, ensure it is enabled.
-                /* FPU Relevant Control Register Bits
-                 * |- CR0.EM (bit 02) -- If set, FPU and vector operations will cause a #UD.
-                 * `- CR0.TS (bit 03) -- Task switched. If set, all FPU and vector ops will cause a #NM.
-                 */
-                asm volatile ("mov %%cr0, %%rdx\n"
-                              "mov $0b1100, %%ax\n"
-                              "not %%ax\n"
-                              "and %%ax, %%dx\n"
-                              "mov %%rdx, %%cr0\n"
-                              "fninit\n"
-                              ::: "rax", "rdx");
-                UART::out("  \033[32mFPU Enabled\033[0m\r\n");
-                SystemCPU->set_fpu_enabled();
-            }
-            else {
-                // FPU not supported, ensure it is disabled.
-                asm volatile ("mov %%cr0, %%rdx\n"
-                              "or $0b1100, %%dx\n"
-                              "mov %%rdx, %%cr0\n"
-                              ::: "rdx");
-                UART::out("  \033[31mFPU Not Supported\033[0m\r\n");
-            }
-            // If FXSAVE/FXRSTOR and FPU are supported and present, setup SSE.
-            if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)) {
-                SystemCPU->set_sse_capable();
-                /* Enable SSE
-                 * |- Clear CR0.EM bit   (bit 2  -- coprocessor emulation) 
-                 * |- Set CR0.MP bit     (bit 1  -- coprocessor monitoring)
-                 * |- Set CR4.OSFXSR bit (bit 9  -- OS provides FXSAVE/FXRSTOR functionality)
-                 * `- Set CR4.OSXMMEXCPT (bit 10 -- OS provides #XM exception handler)
-                 */
-                asm volatile ("mov %%cr0, %%rax\n"
-                              "and $0b1111111111110011, %%ax\n"
-                              "or $0b10, %%ax\n"
-                              "mov %%rax, %%cr0\n"
-                              "mov %%cr4, %%rax\n"
-                              "or $0b11000000000, %%rax\n"
-                              "mov %%rax, %%cr4\n"
-                              ::: "rax");
-                UART::out("  \033[32mSSE Enabled\033[0m\r\n");
-                SystemCPU->set_sse_enabled();
-            }
-            else UART::out("  \033[31mSSE Not Supported\033[0m\r\n");
-        }
-        // Enable XSAVE feature set if CPU supports it.
-        if (regs.C & static_cast<u32>(CPUID_FEATURE::ECX_XSAVE)) {
-            SystemCPU->set_xsave_capable();
-            // Enable XSAVE feature set
-            // `- Set CR4.OSXSAVE bit (bit 18  -- OS provides )
-            asm volatile ("mov %cr4, %rax\n"
-                          "or $0b1000000000000000000, %rax\n"
-                          "mov %rax, %cr4\n");
-            UART::out("  \033[32mXSAVE Enabled\033[0m\r\n");
-            SystemCPU->set_xsave_enabled();
-            // If SSE, AND XSAVE are supported, setup AVX feature set.
-            if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)
-                && regs.C & static_cast<u32>(CPUID_FEATURE::ECX_AVX))
-            {
-                SystemCPU->set_avx_capable();
-                asm volatile ("xor %%rcx, %%rcx\n"
-                              "xgetbv\n"
-                              "or $0b111, %%eax\n"
-                              "xsetbv\n"
-                              ::: "rax", "rbx", "rdx");
-                UART::out("  \033[32mAVX Enabled\033[0m\r\n");
-                SystemCPU->set_avx_enabled();
-            }
-            else UART::out("  \033[31mAVX Not Supported\033[0m\r\n");
-        }
-        else UART::out("  \033[31mXSAVE Not Supported\033[0m\r\n");
-    }
+    //     // Enable FXSAVE/FXRSTOR instructions if CPU supports it.
+    //     // If it is not supported, don't bother trying to support FPU, SSE, etc
+    //     //   as there would be no mechanism to save/load the registers on context switch.
+    //     // TODO: Get logical/physical core bits from CPUID
+    //     // |- 0x0000000b -- Intel
+    //     // |- 0x80000008 -- AMD
+    //     // `- Otherwise: bits are zero, assume single core.
+    //     // TODO: Rewrite task switching code to save/load all supported registers in CPUState.
+    //     if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FXSR)) {
+    //         SystemCPU->set_fxsr_capable();
+    //         asm volatile ("fxsave %0" :: "m"(fxsave_region));
+    //         UART::out("  \033[32mFXSAVE/FXRSTOR Enabled\033[0m\r\n");
+    //         SystemCPU->set_fxsr_enabled();
+    //         // If FXSAVE/FXRSTOR is supported, setup FPU.
+    //         if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FPU)) {
+    //             SystemCPU->set_fpu_capable();
+    //             // FPU supported, ensure it is enabled.
+    //             /* FPU Relevant Control Register Bits
+    //              * |- CR0.EM (bit 02) -- If set, FPU and vector operations will cause a #UD.
+    //              * `- CR0.TS (bit 03) -- Task switched. If set, all FPU and vector ops will cause a #NM.
+    //              */
+    //             asm volatile ("mov %%cr0, %%rdx\n"
+    //                           "mov $0b1100, %%ax\n"
+    //                           "not %%ax\n"
+    //                           "and %%ax, %%dx\n"
+    //                           "mov %%rdx, %%cr0\n"
+    //                           "fninit\n"
+    //                           ::: "rax", "rdx");
+    //             UART::out("  \033[32mFPU Enabled\033[0m\r\n");
+    //             SystemCPU->set_fpu_enabled();
+    //         }
+    //         else {
+    //             // FPU not supported, ensure it is disabled.
+    //             asm volatile ("mov %%cr0, %%rdx\n"
+    //                           "or $0b1100, %%dx\n"
+    //                           "mov %%rdx, %%cr0\n"
+    //                           ::: "rdx");
+    //             UART::out("  \033[31mFPU Not Supported\033[0m\r\n");
+    //         }
+    //         // If FXSAVE/FXRSTOR and FPU are supported and present, setup SSE.
+    //         if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)) {
+    //             SystemCPU->set_sse_capable();
+    //             /* Enable SSE
+    //              * |- Clear CR0.EM bit   (bit 2  -- coprocessor emulation) 
+    //              * |- Set CR0.MP bit     (bit 1  -- coprocessor monitoring)
+    //              * |- Set CR4.OSFXSR bit (bit 9  -- OS provides FXSAVE/FXRSTOR functionality)
+    //              * `- Set CR4.OSXMMEXCPT (bit 10 -- OS provides #XM exception handler)
+    //              */
+    //             asm volatile ("mov %%cr0, %%rax\n"
+    //                           "and $0b1111111111110011, %%ax\n"
+    //                           "or $0b10, %%ax\n"
+    //                           "mov %%rax, %%cr0\n"
+    //                           "mov %%cr4, %%rax\n"
+    //                           "or $0b11000000000, %%rax\n"
+    //                           "mov %%rax, %%cr4\n"
+    //                           ::: "rax");
+    //             UART::out("  \033[32mSSE Enabled\033[0m\r\n");
+    //             SystemCPU->set_sse_enabled();
+    //         }
+    //         else UART::out("  \033[31mSSE Not Supported\033[0m\r\n");
+    //     }
+    //     // Enable XSAVE feature set if CPU supports it.
+    //     if (regs.C & static_cast<u32>(CPUID_FEATURE::ECX_XSAVE)) {
+    //         SystemCPU->set_xsave_capable();
+    //         // Enable XSAVE feature set
+    //         // `- Set CR4.OSXSAVE bit (bit 18  -- OS provides )
+    //         asm volatile ("mov %cr4, %rax\n"
+    //                       "or $0b1000000000000000000, %rax\n"
+    //                       "mov %rax, %cr4\n");
+    //         UART::out("  \033[32mXSAVE Enabled\033[0m\r\n");
+    //         SystemCPU->set_xsave_enabled();
+    //         // If SSE, AND XSAVE are supported, setup AVX feature set.
+    //         if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)
+    //             && regs.C & static_cast<u32>(CPUID_FEATURE::ECX_AVX))
+    //         {
+    //             SystemCPU->set_avx_capable();
+    //             asm volatile ("xor %%rcx, %%rcx\n"
+    //                           "xgetbv\n"
+    //                           "or $0b111, %%eax\n"
+    //                           "xsetbv\n"
+    //                           ::: "rax", "rbx", "rdx");
+    //             UART::out("  \033[32mAVX Enabled\033[0m\r\n");
+    //             SystemCPU->set_avx_enabled();
+    //         }
+    //         else UART::out("  \033[31mAVX Not Supported\033[0m\r\n");
+    //     }
+    //     else UART::out("  \033[31mXSAVE Not Supported\033[0m\r\n");
+    // }
+    
     // TODO: Parse CPUs from ACPI MADT table. For now only support single core.
-    CPU cpu = CPU(SystemCPU);
-    SystemCPU->add_cpu(cpu);
-    SystemCPU->print_debug();
+    ////CPU cpu = CPU(SystemCPU);
+    ////SystemCPU->add_cpu(cpu);
+    ////SystemCPU->print_debug();
     
     // Prepare filesystem drivers.
-    gFATDriver = FATDriver();
-    UART::out("[kUtil]: \033[32mFilesystem drivers prepared successfully\033[0m\r\n");
+    ////gFATDriver = FATDriver();
+    ////UART::out("[kUtil]: \033[32mFilesystem drivers prepared successfully\033[0m\r\n");
     // Initialize Advanced Configuration and Power Management Interface.
-    ACPI::initialize(bInfo->rsdp);
-    UART::out("[kUtil]: \033[32mACPI initialized\033[0m\r\n");
+    ////ACPI::initialize(bInfo->rsdp);
+    ////UART::out("[kUtil]: \033[32mACPI initialized\033[0m\r\n");
     // Enumerate PCI (find hardware devices).
-    prepare_pci();
+    ////prepare_pci();
     
     // Initialize High Precision Event Timer.
-    (void)gHPET.initialize();
+    ////(void)gHPET.initialize();
     // Prepare PS2 mouse.
-    init_ps2_mouse();
+    ////init_ps2_mouse();
     
     // Print the state of the heap just before beginning multi-threading setup.
-    heap_print_debug();
+    ////heap_print_debug();
     //print_efi_memory_map(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
     //print_efi_memory_map_summed(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
-    Memory::print_debug();
+    ////Memory::print_debug();
     
     // Setup task state segment for eventual switch to user-land.
-    TSS::initialize();
+    ////TSS::initialize();
     // Use kernel process switching.
-    Scheduler::initialize(Memory::get_active_page_map());
+    ////Scheduler::initialize(Memory::get_active_page_map());
     
     // Enable IRQ interrupts that will be used.
-    disable_all_interrupts();
-    enable_interrupt(IRQ_SYSTEM_TIMER);
-    enable_interrupt(IRQ_PS2_KEYBOARD);
-    enable_interrupt(IRQ_CASCADED_PIC);
-    enable_interrupt(IRQ_UART_COM1);
-    enable_interrupt(IRQ_REAL_TIMER);
-    enable_interrupt(IRQ_PS2_MOUSE);
+    ////disable_all_interrupts();
+    ////enable_interrupt(IRQ_SYSTEM_TIMER);
+    ////enable_interrupt(IRQ_PS2_KEYBOARD);
+    ////enable_interrupt(IRQ_CASCADED_PIC);
+    ////enable_interrupt(IRQ_UART_COM1);
+    ////enable_interrupt(IRQ_REAL_TIMER);
+    ////enable_interrupt(IRQ_PS2_MOUSE);
 
     // Allow interrupts to trigger.
-    UART::out("[kUtil]: Interrupt masks sent, enabling interrupts.\r\n");
+    ////UART::out("[kUtil]: Interrupt masks sent, enabling interrupts.\r\n");
     asm ("sti");
-    UART::out("    \033[32mInterrupts enabled.\033[0m\r\n");
+    ////UART::out("    \033[32mInterrupts enabled.\033[0m\r\n");
 }

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -156,13 +156,13 @@ void kernel_init(BootInfo* bInfo) {
     Keyboard::gText = Keyboard::BasicTextRenderer();
 
     ////// Initialize the Programmable Interval Timer.
-    ////gPIT = PIT();
-    ////UART::out("[kUtil]: \033[32mProgrammable Interval Timer Initialized\033[0m\r\n");
-    ////UART::out("  Channel 0, H/L Bit Access\r\n");
-    ////UART::out("  Rate Generator, BCD Disabled\r\n");
-    ////UART::out("  Periodic interrupts at \033[33m");
-    ////UART::out(to_string(PIT_FREQUENCY));
-    ////UART::out("hz\033[0m.\r\n");
+    gPIT = PIT();
+    UART::out("[kUtil]: \033[32mProgrammable Interval Timer Initialized\033[0m\r\n");
+    UART::out("  Channel 0, H/L Bit Access\r\n");
+    UART::out("  Rate Generator, BCD Disabled\r\n");
+    UART::out("  Periodic interrupts at \033[33m");
+    UART::out(to_string(PIT_FREQUENCY));
+    UART::out("hz\033[0m.\r\n");
     ////// Initialize the Real Time Clock.
     gRTC = RTC();
     gRTC.set_periodic_int_enabled(true);
@@ -335,7 +335,7 @@ void kernel_init(BootInfo* bInfo) {
     
     // Enable IRQ interrupts that will be used.
     disable_all_interrupts();
-    ////enable_interrupt(IRQ_SYSTEM_TIMER);
+    enable_interrupt(IRQ_SYSTEM_TIMER);
     enable_interrupt(IRQ_PS2_KEYBOARD);
     ////enable_interrupt(IRQ_CASCADED_PIC);
     ////enable_interrupt(IRQ_UART_COM1);

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -315,7 +315,7 @@ void kernel_init(BootInfo* bInfo) {
     ACPI::initialize(bInfo->rsdp);
     UART::out("[kUtil]: \033[32mACPI initialized\033[0m\r\n");
     // Enumerate PCI (find hardware devices).
-    ////prepare_pci();
+    prepare_pci();
     
     // Initialize High Precision Event Timer.
     (void)gHPET.initialize();

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -133,9 +133,9 @@ void kernel_init(BootInfo* bInfo) {
     // Setup memory state from EFI memory map.
     Memory::init_physical_efi(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
     // Setup virtual to physical memory mapping.
-    ////Memory::init_virtual();
+    Memory::init_virtual();
     // Setup dynamic memory allocation (`new`, `delete`).
-    ////init_heap();
+    init_heap();
 
     // Prepare Global Descriptor Table Descriptor.
     GDTDescriptor GDTD = GDTDescriptor(sizeof(GDT) - 1, (u64)&gGDT);

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -193,11 +193,11 @@ void kernel_init(BootInfo* bInfo) {
     if (supportCPUID) {
         SystemCPU->set_cpuid_capable();
         UART::out("[kUtil]: \033[32mCPUID is supported\033[0m\r\n");
-        ////char* cpuVendorID = cpuid_string(0);
-        ////SystemCPU->set_vendor_id(cpuVendorID);
-        ////UART::out("  CPU Vendor ID: ");
-        ////UART::out((u8*)SystemCPU->get_vendor_id(), 12);
-        ////UART::out("\r\n");
+        char* cpuVendorID = cpuid_string(0);
+        SystemCPU->set_vendor_id(cpuVendorID);
+        UART::out("  CPU Vendor ID: ");
+        UART::out((u8*)SystemCPU->get_vendor_id(), 12);
+        UART::out("\r\n");
         /* Current functionality of giant `if` statemnt:
          * |- Setup FXSAVE/FXRSTOR
          * |  |- Setup FPU
@@ -211,17 +211,17 @@ void kernel_init(BootInfo* bInfo) {
          *   https://wiki.osdev.org/Detecting_CPU_Topology_(80x86)#Using_CPUID
          */
 
-    //     CPUIDRegisters regs;
-    //     cpuid(1, regs);
+        ////CPUIDRegisters regs;
+        ////cpuid(1, regs);
 
-    //     // Enable FXSAVE/FXRSTOR instructions if CPU supports it.
-    //     // If it is not supported, don't bother trying to support FPU, SSE, etc
-    //     //   as there would be no mechanism to save/load the registers on context switch.
-    //     // TODO: Get logical/physical core bits from CPUID
-    //     // |- 0x0000000b -- Intel
-    //     // |- 0x80000008 -- AMD
-    //     // `- Otherwise: bits are zero, assume single core.
-    //     // TODO: Rewrite task switching code to save/load all supported registers in CPUState.
+    // Enable FXSAVE/FXRSTOR instructions if CPU supports it.
+    // If it is not supported, don't bother trying to support FPU, SSE, etc
+    //   as there would be no mechanism to save/load the registers on context switch.
+    // TODO: Get logical/physical core bits from CPUID
+    // |- 0x0000000b -- Intel
+    // |- 0x80000008 -- AMD
+    // `- Otherwise: bits are zero, assume single core.
+    // TODO: Rewrite task switching code to save/load all supported registers in CPUState.
     //     if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FXSR)) {
     //         SystemCPU->set_fxsr_capable();
     //         asm volatile ("fxsave %0" :: "m"(fxsave_region));

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -228,52 +228,52 @@ void kernel_init(BootInfo* bInfo) {
         UART::out("  \033[32mFXSAVE/FXRSTOR Enabled\033[0m\r\n");
         SystemCPU->set_fxsr_enabled();
         // If FXSAVE/FXRSTOR is supported, setup FPU.
-    //    if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FPU)) {
-    //        SystemCPU->set_fpu_capable();
-    //             // FPU supported, ensure it is enabled.
-    //             /* FPU Relevant Control Register Bits
-    //              * |- CR0.EM (bit 02) -- If set, FPU and vector operations will cause a #UD.
-    //              * `- CR0.TS (bit 03) -- Task switched. If set, all FPU and vector ops will cause a #NM.
-    //              */
-    //             asm volatile ("mov %%cr0, %%rdx\n"
-    //                           "mov $0b1100, %%ax\n"
-    //                           "not %%ax\n"
-    //                           "and %%ax, %%dx\n"
-    //                           "mov %%rdx, %%cr0\n"
-    //                           "fninit\n"
-    //                           ::: "rax", "rdx");
-    //             UART::out("  \033[32mFPU Enabled\033[0m\r\n");
-    //             SystemCPU->set_fpu_enabled();
-    //    }
-    //    else {
-    //        // FPU not supported, ensure it is disabled.
-    //        asm volatile ("mov %%cr0, %%rdx\n"
-    //                      "or $0b1100, %%dx\n"
-    //                      "mov %%rdx, %%cr0\n"
-    //                      ::: "rdx");
-    //        UART::out("  \033[31mFPU Not Supported\033[0m\r\n");
-    //    }
-    //         // If FXSAVE/FXRSTOR and FPU are supported and present, setup SSE.
-    //         if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)) {
-    //             SystemCPU->set_sse_capable();
-    //             /* Enable SSE
-    //              * |- Clear CR0.EM bit   (bit 2  -- coprocessor emulation) 
-    //              * |- Set CR0.MP bit     (bit 1  -- coprocessor monitoring)
-    //              * |- Set CR4.OSFXSR bit (bit 9  -- OS provides FXSAVE/FXRSTOR functionality)
-    //              * `- Set CR4.OSXMMEXCPT (bit 10 -- OS provides #XM exception handler)
-    //              */
-    //             asm volatile ("mov %%cr0, %%rax\n"
-    //                           "and $0b1111111111110011, %%ax\n"
-    //                           "or $0b10, %%ax\n"
-    //                           "mov %%rax, %%cr0\n"
-    //                           "mov %%cr4, %%rax\n"
-    //                           "or $0b11000000000, %%rax\n"
-    //                           "mov %%rax, %%cr4\n"
-    //                           ::: "rax");
-    //             UART::out("  \033[32mSSE Enabled\033[0m\r\n");
-    //             SystemCPU->set_sse_enabled();
-    //         }
-    //         else UART::out("  \033[31mSSE Not Supported\033[0m\r\n");
+        if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FPU)) {
+            SystemCPU->set_fpu_capable();
+            // FPU supported, ensure it is enabled.
+            /* FPU Relevant Control Register Bits
+             * |- CR0.EM (bit 02) -- If set, FPU and vector operations will cause a #UD.
+             * `- CR0.TS (bit 03) -- Task switched. If set, all FPU and vector ops will cause a #NM.
+             */
+            asm volatile ("mov %%cr0, %%rdx\n"
+                          "mov $0b1100, %%ax\n"
+                          "not %%ax\n"
+                          "and %%ax, %%dx\n"
+                          "mov %%rdx, %%cr0\n"
+                          "fninit\n"
+                          ::: "rax", "rdx");
+            UART::out("  \033[32mFPU Enabled\033[0m\r\n");
+            SystemCPU->set_fpu_enabled();
+        }
+        else {
+            // FPU not supported, ensure it is disabled.
+            asm volatile ("mov %%cr0, %%rdx\n"
+                          "or $0b1100, %%dx\n"
+                          "mov %%rdx, %%cr0\n"
+                          ::: "rdx");
+            UART::out("  \033[31mFPU Not Supported\033[0m\r\n");
+        }
+        // If FXSAVE/FXRSTOR and FPU are supported and present, setup SSE.
+    ////if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)) {
+    ////    SystemCPU->set_sse_capable();
+    ////    /* Enable SSE
+    ////     * |- Clear CR0.EM bit   (bit 2  -- coprocessor emulation) 
+    ////     * |- Set CR0.MP bit     (bit 1  -- coprocessor monitoring)
+    ////     * |- Set CR4.OSFXSR bit (bit 9  -- OS provides FXSAVE/FXRSTOR functionality)
+    ////     * `- Set CR4.OSXMMEXCPT (bit 10 -- OS provides #XM exception handler)
+    ////     */
+    ////    asm volatile ("mov %%cr0, %%rax\n"
+    ////                  "and $0b1111111111110011, %%ax\n"
+    ////                  "or $0b10, %%ax\n"
+    ////                  "mov %%rax, %%cr0\n"
+    ////                  "mov %%cr4, %%rax\n"
+    ////                  "or $0b11000000000, %%rax\n"
+    ////                  "mov %%rax, %%cr4\n"
+    ////                  ::: "rax");
+    ////    UART::out("  \033[32mSSE Enabled\033[0m\r\n");
+    ////    SystemCPU->set_sse_enabled();
+    ////}
+    ////else UART::out("  \033[31mSSE Not Supported\033[0m\r\n");
     }
     //     // Enable XSAVE feature set if CPU supports it.
     //     if (regs.C & static_cast<u32>(CPUID_FEATURE::ECX_XSAVE)) {

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -211,8 +211,8 @@ void kernel_init(BootInfo* bInfo) {
          *   https://wiki.osdev.org/Detecting_CPU_Topology_(80x86)#Using_CPUID
          */
 
-        ////CPUIDRegisters regs;
-        ////cpuid(1, regs);
+        CPUIDRegisters regs;
+        cpuid(1, regs);
 
     // Enable FXSAVE/FXRSTOR instructions if CPU supports it.
     // If it is not supported, don't bother trying to support FPU, SSE, etc
@@ -222,14 +222,14 @@ void kernel_init(BootInfo* bInfo) {
     // |- 0x80000008 -- AMD
     // `- Otherwise: bits are zero, assume single core.
     // TODO: Rewrite task switching code to save/load all supported registers in CPUState.
-    //     if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FXSR)) {
-    //         SystemCPU->set_fxsr_capable();
-    //         asm volatile ("fxsave %0" :: "m"(fxsave_region));
-    //         UART::out("  \033[32mFXSAVE/FXRSTOR Enabled\033[0m\r\n");
-    //         SystemCPU->set_fxsr_enabled();
-    //         // If FXSAVE/FXRSTOR is supported, setup FPU.
-    //         if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FPU)) {
-    //             SystemCPU->set_fpu_capable();
+    if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FXSR)) {
+        SystemCPU->set_fxsr_capable();
+        asm volatile ("fxsave %0" :: "m"(fxsave_region));
+        UART::out("  \033[32mFXSAVE/FXRSTOR Enabled\033[0m\r\n");
+        SystemCPU->set_fxsr_enabled();
+        // If FXSAVE/FXRSTOR is supported, setup FPU.
+    //    if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_FPU)) {
+    //        SystemCPU->set_fpu_capable();
     //             // FPU supported, ensure it is enabled.
     //             /* FPU Relevant Control Register Bits
     //              * |- CR0.EM (bit 02) -- If set, FPU and vector operations will cause a #UD.
@@ -244,15 +244,15 @@ void kernel_init(BootInfo* bInfo) {
     //                           ::: "rax", "rdx");
     //             UART::out("  \033[32mFPU Enabled\033[0m\r\n");
     //             SystemCPU->set_fpu_enabled();
-    //         }
-    //         else {
-    //             // FPU not supported, ensure it is disabled.
-    //             asm volatile ("mov %%cr0, %%rdx\n"
-    //                           "or $0b1100, %%dx\n"
-    //                           "mov %%rdx, %%cr0\n"
-    //                           ::: "rdx");
-    //             UART::out("  \033[31mFPU Not Supported\033[0m\r\n");
-    //         }
+    //    }
+    //    else {
+    //        // FPU not supported, ensure it is disabled.
+    //        asm volatile ("mov %%cr0, %%rdx\n"
+    //                      "or $0b1100, %%dx\n"
+    //                      "mov %%rdx, %%cr0\n"
+    //                      ::: "rdx");
+    //        UART::out("  \033[31mFPU Not Supported\033[0m\r\n");
+    //    }
     //         // If FXSAVE/FXRSTOR and FPU are supported and present, setup SSE.
     //         if (regs.D & static_cast<u32>(CPUID_FEATURE::EDX_SSE)) {
     //             SystemCPU->set_sse_capable();
@@ -274,7 +274,7 @@ void kernel_init(BootInfo* bInfo) {
     //             SystemCPU->set_sse_enabled();
     //         }
     //         else UART::out("  \033[31mSSE Not Supported\033[0m\r\n");
-    //     }
+    }
     //     // Enable XSAVE feature set if CPU supports it.
     //     if (regs.C & static_cast<u32>(CPUID_FEATURE::ECX_XSAVE)) {
     //         SystemCPU->set_xsave_capable();

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -187,12 +187,12 @@ void kernel_init(BootInfo* bInfo) {
     UART::out("\033[0m\r\n");
 
     // Store feature set of CPU (capabilities).
-    ////SystemCPU = new CPUDescription();
+    SystemCPU = new CPUDescription();
     // Check for CPUID availability ('ID' bit in rflags register modifiable)
-    ////bool supportCPUID = static_cast<bool>(cpuid_support());
-    ////if (supportCPUID) {
-        ////SystemCPU->set_cpuid_capable();
-        ////UART::out("[kUtil]: \033[32mCPUID is supported\033[0m\r\n");
+    bool supportCPUID = static_cast<bool>(cpuid_support());
+    if (supportCPUID) {
+        SystemCPU->set_cpuid_capable();
+        UART::out("[kUtil]: \033[32mCPUID is supported\033[0m\r\n");
         ////char* cpuVendorID = cpuid_string(0);
         ////SystemCPU->set_vendor_id(cpuVendorID);
         ////UART::out("  CPU Vendor ID: ");
@@ -301,12 +301,12 @@ void kernel_init(BootInfo* bInfo) {
     //         else UART::out("  \033[31mAVX Not Supported\033[0m\r\n");
     //     }
     //     else UART::out("  \033[31mXSAVE Not Supported\033[0m\r\n");
-    // }
+    }
     
     // TODO: Parse CPUs from ACPI MADT table. For now only support single core.
-    ////CPU cpu = CPU(SystemCPU);
-    ////SystemCPU->add_cpu(cpu);
-    ////SystemCPU->print_debug();
+    CPU cpu = CPU(SystemCPU);
+    SystemCPU->add_cpu(cpu);
+    SystemCPU->print_debug();
     
     // Prepare filesystem drivers.
     gFATDriver = FATDriver();

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -164,12 +164,12 @@ void kernel_init(BootInfo* bInfo) {
     ////UART::out(to_string(PIT_FREQUENCY));
     ////UART::out("hz\033[0m.\r\n");
     ////// Initialize the Real Time Clock.
-    ////gRTC = RTC();
-    ////gRTC.set_periodic_int_enabled(true);
-    ////UART::out("[kUtil]: \033[32mReal Time Clock Initialized\033[0m\r\n");
-    ////UART::out("  Periodic interrupts enabled at \033[33m");
-    ////UART::out(to_string((double)RTC_PERIODIC_HERTZ));
-    ////UART::out("hz\033[0m\r\n");
+    gRTC = RTC();
+    gRTC.set_periodic_int_enabled(true);
+    UART::out("[kUtil]: \033[32mReal Time Clock Initialized\033[0m\r\n");
+    UART::out("  Periodic interrupts enabled at \033[33m");
+    UART::out(to_string((double)RTC_PERIODIC_HERTZ));
+    UART::out("hz\033[0m\r\n");
     
     // Print real time to serial output.
     ////UART::out("[kUtil]: \033[1;33mNow is ");

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -144,8 +144,8 @@ void kernel_init(BootInfo* bInfo) {
     prepare_interrupts();
 
     // Setup random number generators.
-    ////gRandomLCG = LCG();
-    ////gRandomLFSR = LFSR();
+    gRandomLCG = LCG();
+    gRandomLFSR = LFSR();
 
     ////// Create basic framebuffer renderer.
     UART::out("[kUtil]: Setting up Graphics Output Protocol Renderer\r\n");
@@ -309,11 +309,11 @@ void kernel_init(BootInfo* bInfo) {
     ////SystemCPU->print_debug();
     
     // Prepare filesystem drivers.
-    ////gFATDriver = FATDriver();
-    ////UART::out("[kUtil]: \033[32mFilesystem drivers prepared successfully\033[0m\r\n");
+    gFATDriver = FATDriver();
+    UART::out("[kUtil]: \033[32mFilesystem drivers prepared successfully\033[0m\r\n");
     // Initialize Advanced Configuration and Power Management Interface.
-    ////ACPI::initialize(bInfo->rsdp);
-    ////UART::out("[kUtil]: \033[32mACPI initialized\033[0m\r\n");
+    ACPI::initialize(bInfo->rsdp);
+    UART::out("[kUtil]: \033[32mACPI initialized\033[0m\r\n");
     // Enumerate PCI (find hardware devices).
     ////prepare_pci();
     

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -141,7 +141,7 @@ void kernel_init(BootInfo* bInfo) {
     GDTDescriptor GDTD = GDTDescriptor(sizeof(GDT) - 1, (u64)&gGDT);
     LoadGDT(&GDTD);
     // Prepare Interrupt Descriptor Table.
-    ////prepare_interrupts();
+    prepare_interrupts();
 
     // Setup random number generators.
     ////gRandomLCG = LCG();

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -148,12 +148,12 @@ void kernel_init(BootInfo* bInfo) {
     ////gRandomLFSR = LFSR();
 
     ////// Create basic framebuffer renderer.
-    ////UART::out("[kUtil]: Setting up Graphics Output Protocol Renderer\r\n");
-    ////gRend = BasicRenderer(bInfo->framebuffer, bInfo->font);
-    ////UART::out("  \033[32mSetup Successful\033[0m\r\n");
-    ////draw_boot_gfx();
+    UART::out("[kUtil]: Setting up Graphics Output Protocol Renderer\r\n");
+    gRend = BasicRenderer(bInfo->framebuffer, bInfo->font);
+    UART::out("  \033[32mSetup Successful\033[0m\r\n");
+    draw_boot_gfx();
     ////// Create basic text renderer for the keyboard.
-    ////Keyboard::gText = Keyboard::BasicTextRenderer();
+    Keyboard::gText = Keyboard::BasicTextRenderer();
 
     ////// Initialize the Programmable Interval Timer.
     ////gPIT = PIT();
@@ -336,7 +336,7 @@ void kernel_init(BootInfo* bInfo) {
     // Enable IRQ interrupts that will be used.
     disable_all_interrupts();
     ////enable_interrupt(IRQ_SYSTEM_TIMER);
-    ////enable_interrupt(IRQ_PS2_KEYBOARD);
+    enable_interrupt(IRQ_PS2_KEYBOARD);
     ////enable_interrupt(IRQ_CASCADED_PIC);
     ////enable_interrupt(IRQ_UART_COM1);
     ////enable_interrupt(IRQ_REAL_TIMER);

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -126,8 +126,8 @@ void kernel_init(BootInfo* bInfo) {
     asm ("cli");
 
     // Setup serial communications chip.
-    ////UART::initialize();
-    ////UART::out("\r\n!===--- You are now booting into \033[1;33mLensorOS\033[0m ---===!\r\n\r\n");
+    UART::initialize();
+    UART::out("\r\n!===--- You are now booting into \033[1;33mLensorOS\033[0m ---===!\r\n\r\n");
     // Parse memory map passed by bootloader.
     // Setup dynamic memory allocation.
     // Setup memory state from EFI memory map.

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -172,19 +172,19 @@ void kernel_init(BootInfo* bInfo) {
     UART::out("hz\033[0m\r\n");
     
     // Print real time to serial output.
-    ////UART::out("[kUtil]: \033[1;33mNow is ");
-    ////UART::out(to_string(gRTC.Time.hour));
-    ////UART::outc(':');
-    ////UART::out(to_string(gRTC.Time.minute));
-    ////UART::outc(':');
-    ////UART::out(to_string(gRTC.Time.second));
-    ////UART::out(" on ");
-    ////UART::out(to_string(gRTC.Time.year));
-    ////UART::outc('-');
-    ////UART::out(to_string(gRTC.Time.month));
-    ////UART::outc('-');
-    ////UART::out(to_string(gRTC.Time.date));
-    ////UART::out("\033[0m\r\n");
+    UART::out("[kUtil]: \033[1;33mNow is ");
+    UART::out(to_string(gRTC.Time.hour));
+    UART::outc(':');
+    UART::out(to_string(gRTC.Time.minute));
+    UART::outc(':');
+    UART::out(to_string(gRTC.Time.second));
+    UART::out(" on ");
+    UART::out(to_string(gRTC.Time.year));
+    UART::outc('-');
+    UART::out(to_string(gRTC.Time.month));
+    UART::outc('-');
+    UART::out(to_string(gRTC.Time.date));
+    UART::out("\033[0m\r\n");
 
     // Store feature set of CPU (capabilities).
     ////SystemCPU = new CPUDescription();
@@ -318,15 +318,15 @@ void kernel_init(BootInfo* bInfo) {
     ////prepare_pci();
     
     // Initialize High Precision Event Timer.
-    ////(void)gHPET.initialize();
+    (void)gHPET.initialize();
     // Prepare PS2 mouse.
     ////init_ps2_mouse();
     
     // Print the state of the heap just before beginning multi-threading setup.
-    ////heap_print_debug();
+    heap_print_debug();
     //print_efi_memory_map(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
     //print_efi_memory_map_summed(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
-    ////Memory::print_debug();
+    Memory::print_debug();
     
     // Setup task state segment for eventual switch to user-land.
     ////TSS::initialize();
@@ -334,7 +334,7 @@ void kernel_init(BootInfo* bInfo) {
     ////Scheduler::initialize(Memory::get_active_page_map());
     
     // Enable IRQ interrupts that will be used.
-    ////disable_all_interrupts();
+    disable_all_interrupts();
     ////enable_interrupt(IRQ_SYSTEM_TIMER);
     ////enable_interrupt(IRQ_PS2_KEYBOARD);
     ////enable_interrupt(IRQ_CASCADED_PIC);
@@ -343,7 +343,7 @@ void kernel_init(BootInfo* bInfo) {
     ////enable_interrupt(IRQ_PS2_MOUSE);
 
     // Allow interrupts to trigger.
-    ////UART::out("[kUtil]: Interrupt masks sent, enabling interrupts.\r\n");
+    UART::out("[kUtil]: Interrupt masks sent, enabling interrupts.\r\n");
     asm ("sti");
-    ////UART::out("    \033[32mInterrupts enabled.\033[0m\r\n");
+    UART::out("    \033[32mInterrupts enabled.\033[0m\r\n");
 }

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -328,17 +328,18 @@ void kernel_init(BootInfo* bInfo) {
     //print_efi_memory_map_summed(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
     Memory::print_debug();
     
+    // The scheduler causes VBOX to hang forever for some reason.
     // Setup task state segment for eventual switch to user-land.
-    ////TSS::initialize();
+    TSS::initialize();
     // Use kernel process switching.
-    ////Scheduler::initialize(Memory::get_active_page_map());
+    Scheduler::initialize();
     
     // Enable IRQ interrupts that will be used.
     disable_all_interrupts();
     enable_interrupt(IRQ_SYSTEM_TIMER);
     enable_interrupt(IRQ_PS2_KEYBOARD);
-    ////enable_interrupt(IRQ_CASCADED_PIC);
-    ////enable_interrupt(IRQ_UART_COM1);
+    enable_interrupt(IRQ_CASCADED_PIC);
+    enable_interrupt(IRQ_UART_COM1);
     enable_interrupt(IRQ_REAL_TIMER);
     enable_interrupt(IRQ_PS2_MOUSE);
 

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -131,7 +131,7 @@ void kernel_init(BootInfo* bInfo) {
     // Parse memory map passed by bootloader.
     // Setup dynamic memory allocation.
     // Setup memory state from EFI memory map.
-    ////Memory::init_physical_efi(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
+    Memory::init_physical_efi(bInfo->map, bInfo->mapSize, bInfo->mapDescSize);
     // Setup virtual to physical memory mapping.
     ////Memory::init_virtual();
     // Setup dynamic memory allocation (`new`, `delete`).

--- a/kernel/src/kUtility.cpp
+++ b/kernel/src/kUtility.cpp
@@ -320,7 +320,7 @@ void kernel_init(BootInfo* bInfo) {
     // Initialize High Precision Event Timer.
     (void)gHPET.initialize();
     // Prepare PS2 mouse.
-    ////init_ps2_mouse();
+    init_ps2_mouse();
     
     // Print the state of the heap just before beginning multi-threading setup.
     heap_print_debug();
@@ -339,8 +339,8 @@ void kernel_init(BootInfo* bInfo) {
     enable_interrupt(IRQ_PS2_KEYBOARD);
     ////enable_interrupt(IRQ_CASCADED_PIC);
     ////enable_interrupt(IRQ_UART_COM1);
-    ////enable_interrupt(IRQ_REAL_TIMER);
-    ////enable_interrupt(IRQ_PS2_MOUSE);
+    enable_interrupt(IRQ_REAL_TIMER);
+    enable_interrupt(IRQ_PS2_MOUSE);
 
     // Allow interrupts to trigger.
     UART::out("[kUtil]: Interrupt masks sent, enabling interrupts.\r\n");

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -239,9 +239,9 @@ extern "C" void _start(BootInfo* bInfo) {
         print_now(debugInfoX);
         gRend.crlf(debugInfoX);
         // PRINT PIT ELAPSED TIME.
-        //    gRend.puts("PIT Elapsed: ");
-        //    gRend.puts(to_string(gPIT.seconds_since_boot()));
-        //    gRend.crlf(debugInfoX);
+        gRend.puts("PIT Elapsed: ");
+        gRend.puts(to_string(gPIT.seconds_since_boot()));
+        gRend.crlf(debugInfoX);
         // PRINT RTC ELAPSED TIME.
         gRend.puts("RTC Elapsed: ");
         gRend.puts(to_string(gRTC.seconds_since_boot()));

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -185,11 +185,8 @@
 void* userland_function;
 
 extern "C" void _start(BootInfo* bInfo) {
-
-                   (void)         bInfo; 
-
     // The heavy lifting is done within the `kernel_init` function (found in `kUtility.cpp`).
-    //kernel_init(bInfo);
+    kernel_init(bInfo);
     //UART::out("\r\n\033[1;33m!===--- You have now booted into LensorOS ---===!\033[0m\r\n");
     //// Clear + swap screen (ensure known state: blank).
     //gRend.clear(0x00000000);

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -53,8 +53,9 @@
  * |     `- This will allow me to write userland programs that will know where to
  * |          look for libc and standard includes relative to LensorOS's root directory.
  * |
+ * |- Use LinkedList to store AHCI Ports instead of pointer mumbo-jumbo that is currently going on.
  * |- HPET: Final step to get interrupts working (init comparators).
- * |- Sound: Implement support for hardware sound cards (SoundBlaster16, Intel HDA, etc).
+ * |- Sound: Implement support for hardware sound cards (AC97, SoundBlaster16, Intel HDA, etc).
  * |
  * |- Further modify cross compiler to make an OS specific toolchain.
  * |  `- This would allow for customizing default include,

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -187,21 +187,21 @@ void* userland_function;
 extern "C" void _start(BootInfo* bInfo) {
     // The heavy lifting is done within the `kernel_init` function (found in `kUtility.cpp`).
     kernel_init(bInfo);
-    //UART::out("\r\n\033[1;33m!===--- You have now booted into LensorOS ---===!\033[0m\r\n");
+    UART::out("\r\n\033[1;33m!===--- You have now booted into LensorOS ---===!\033[0m\r\n");
     //// Clear + swap screen (ensure known state: blank).
-    //gRend.clear(0x00000000);
-    //gRend.swap();
+    gRend.clear(0x00000000);
+    gRend.swap();
     ///// GPLv3 LICENSE REQUIREMENT (interactive terminal must print copyright notice).
-    //const char* GPLv3 = "<LensorOS>  Copyright (C) <2022>  <Rylan Lens Kellogg>";
+    const char* GPLv3 = "<LensorOS>  Copyright (C) <2022>  <Rylan Lens Kellogg>";
     //// TO SERIAL
-    //UART::out(GPLv3);
-    //UART::out("\r\n\r\n");
+    UART::out(GPLv3);
+    UART::out("\r\n\r\n");
     //// TO SCREEN
-    //gRend.BackgroundColor = 0xffffffff;
-    //gRend.puts(GPLv3, 0x00000000);
-    //gRend.BackgroundColor = 0x00000000;
-    //gRend.crlf();
-    //gRend.swap({0, 0}, {80000, gRend.Font->PSF1_Header->CharacterSize});
+    gRend.BackgroundColor = 0xffffffff;
+    gRend.puts(GPLv3, 0x00000000);
+    gRend.BackgroundColor = 0x00000000;
+    gRend.crlf();
+    gRend.swap({0, 0}, {80000, gRend.Font->PSF1_Header->CharacterSize});
     /// END GPLv3 LICENSE REQUIREMENT.
 
     // USERLAND SWITCH TESTING
@@ -217,17 +217,17 @@ extern "C" void _start(BootInfo* bInfo) {
     //UART::out("Null de-referenced!\r\n");
 
     // I'm lovin' it :^) (Plays Maccy's theme).
-    //constexpr double MACCYS_BPM = 125;
-    //constexpr double MACCYS_STEP_LENGTH_SECONDS = (60 / MACCYS_BPM) / 4;
-    //gPIT.prepare_wait_seconds(MACCYS_STEP_LENGTH_SECONDS);
-    //gPIT.play_sound(262, MACCYS_STEP_LENGTH_SECONDS); // C4
-    //gPIT.play_sound(294, MACCYS_STEP_LENGTH_SECONDS); // D4
-    //gPIT.wait();                                      // Rest
-    //gPIT.play_sound(330, MACCYS_STEP_LENGTH_SECONDS); // E4
-    //gPIT.wait();                                      // Rest
-    //gPIT.play_sound(440, MACCYS_STEP_LENGTH_SECONDS); // A4
-    //gPIT.wait();                                      // Rest
-    //gPIT.play_sound(392, MACCYS_STEP_LENGTH_SECONDS); // G4
+    constexpr double MACCYS_BPM = 125;
+    constexpr double MACCYS_STEP_LENGTH_SECONDS = (60 / MACCYS_BPM) / 4;
+    gPIT.prepare_wait_seconds(MACCYS_STEP_LENGTH_SECONDS);
+    gPIT.play_sound(262, MACCYS_STEP_LENGTH_SECONDS); // C4
+    gPIT.play_sound(294, MACCYS_STEP_LENGTH_SECONDS); // D4
+    gPIT.wait();                                      // Rest
+    gPIT.play_sound(330, MACCYS_STEP_LENGTH_SECONDS); // E4
+    gPIT.wait();                                      // Rest
+    gPIT.play_sound(440, MACCYS_STEP_LENGTH_SECONDS); // A4
+    gPIT.wait();                                      // Rest
+    gPIT.play_sound(392, MACCYS_STEP_LENGTH_SECONDS); // G4
 
     // Start keyboard input at draw position, not origin.
     Keyboard::gText.set_cursor_from_pixel_position(gRend.DrawPos);

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -118,61 +118,61 @@
  * |
  * `- Add GPLv3 license header to top of every source file (exactly as seen in LICENSE).
  */
-//void print_memory_info() {
-//    u32 startOffset = gRend.DrawPos.x;
-//    gRend.puts("Memory Info:");
-//    gRend.crlf(startOffset);
-//    gRend.puts("|- Total RAM: ");
-//    gRend.puts(to_string(Memory::get_total_ram() / 1024 / 1024));
-//    gRend.puts(" MiB (");
-//    gRend.puts(to_string(Memory::get_total_ram() / 1024));
-//    gRend.puts(" KiB)");
-//    gRend.crlf(startOffset);
-//    gRend.puts("|- Free RAM: ");
-//    gRend.puts(to_string(Memory::get_free_ram() / 1024 / 1024));
-//    gRend.puts(" MiB (");
-//    gRend.puts(to_string(Memory::get_free_ram() / 1024));
-//    gRend.puts(" KiB)");
-//    gRend.crlf(startOffset);
-//    gRend.puts("`- Used RAM: ");
-//    gRend.puts(to_string(Memory::get_used_ram() / 1024 / 1024));
-//    gRend.puts(" MiB (");
-//    gRend.puts(to_string(Memory::get_used_ram() / 1024));
-//    gRend.puts(" KiB)");
-//    gRend.crlf(startOffset);
-//}
+void print_memory_info() {
+    u32 startOffset = gRend.DrawPos.x;
+    gRend.puts("Memory Info:");
+    gRend.crlf(startOffset);
+    gRend.puts("|- Total RAM: ");
+    gRend.puts(to_string(Memory::get_total_ram() / 1024 / 1024));
+    gRend.puts(" MiB (");
+    gRend.puts(to_string(Memory::get_total_ram() / 1024));
+    gRend.puts(" KiB)");
+    gRend.crlf(startOffset);
+    gRend.puts("|- Free RAM: ");
+    gRend.puts(to_string(Memory::get_free_ram() / 1024 / 1024));
+    gRend.puts(" MiB (");
+    gRend.puts(to_string(Memory::get_free_ram() / 1024));
+    gRend.puts(" KiB)");
+    gRend.crlf(startOffset);
+    gRend.puts("`- Used RAM: ");
+    gRend.puts(to_string(Memory::get_used_ram() / 1024 / 1024));
+    gRend.puts(" MiB (");
+    gRend.puts(to_string(Memory::get_used_ram() / 1024));
+    gRend.puts(" KiB)");
+    gRend.crlf(startOffset);
+}
 
-//void srl_memory_info() {
-//    UART::out("\r\nMemory Info:\r\n|- Total RAM: ");
-//    UART::out(to_string(Memory::get_total_ram() / 1024 / 1024));
-//    UART::out("MiB (");
-//    UART::out(to_string(Memory::get_total_ram() / 1024));
-//    UART::out("KiB)\r\n|- Free RAM: ");
-//    UART::out(to_string(Memory::get_free_ram() / 1024 / 1024));
-//    UART::out(" MiB (");
-//    UART::out(to_string(Memory::get_free_ram() / 1024));
-//    UART::out(" KiB)\r\n`- Used RAM: ");
-//    UART::out(to_string(Memory::get_used_ram() / 1024 / 1024));
-//    UART::out(" MiB (");
-//    UART::out(to_string(Memory::get_used_ram() / 1024));
-//    UART::out(" KiB)\r\n");
-//}
+void srl_memory_info() {
+    UART::out("\r\nMemory Info:\r\n|- Total RAM: ");
+    UART::out(to_string(Memory::get_total_ram() / 1024 / 1024));
+    UART::out("MiB (");
+    UART::out(to_string(Memory::get_total_ram() / 1024));
+    UART::out("KiB)\r\n|- Free RAM: ");
+    UART::out(to_string(Memory::get_free_ram() / 1024 / 1024));
+    UART::out(" MiB (");
+    UART::out(to_string(Memory::get_free_ram() / 1024));
+    UART::out(" KiB)\r\n`- Used RAM: ");
+    UART::out(to_string(Memory::get_used_ram() / 1024 / 1024));
+    UART::out(" MiB (");
+    UART::out(to_string(Memory::get_used_ram() / 1024));
+    UART::out(" KiB)\r\n");
+}
 
-//void print_now(u64 xOffset = 0) {
-//    gRend.puts("Now is ");
-//    gRend.puts(to_string(gRTC.Time.hour));
-//    gRend.putchar(':');
-//    gRend.puts(to_string(gRTC.Time.minute));
-//    gRend.putchar(':');
-//    gRend.puts(to_string(gRTC.Time.second));
-//    gRend.puts(" on ");
-//    gRend.puts(to_string(gRTC.Time.year));
-//    gRend.putchar('-');
-//    gRend.puts(to_string(gRTC.Time.month));
-//    gRend.putchar('-');
-//    gRend.puts(to_string(gRTC.Time.date));
-//    gRend.crlf(xOffset);
-//}
+void print_now(u64 xOffset = 0) {
+    gRend.puts("Now is ");
+    gRend.puts(to_string(gRTC.Time.hour));
+    gRend.putchar(':');
+    gRend.puts(to_string(gRTC.Time.minute));
+    gRend.putchar(':');
+    gRend.puts(to_string(gRTC.Time.second));
+    gRend.puts(" on ");
+    gRend.puts(to_string(gRTC.Time.year));
+    gRend.putchar('-');
+    gRend.puts(to_string(gRTC.Time.month));
+    gRend.putchar('-');
+    gRend.puts(to_string(gRTC.Time.date));
+    gRend.crlf(xOffset);
+}
 
 //void test_userland_function() {
 //    for (;;) {
@@ -230,32 +230,32 @@ extern "C" void _start(BootInfo* bInfo) {
     //gPIT.play_sound(392, MACCYS_STEP_LENGTH_SECONDS); // G4
 
     // Start keyboard input at draw position, not origin.
-    //Keyboard::gText.set_cursor_from_pixel_position(gRend.DrawPos);
-    //u32 debugInfoX = gRend.Target->PixelWidth - 300;
-    //while (true) {
-    //    gRend.DrawPos = {debugInfoX, 0};
-    //    // PRINT REAL TIME
-    //    gRTC.update_data();
-    //    print_now(debugInfoX);
-    //    gRend.crlf(debugInfoX);
-    //    // PRINT PIT ELAPSED TIME.
+    Keyboard::gText.set_cursor_from_pixel_position(gRend.DrawPos);
+    u32 debugInfoX = gRend.Target->PixelWidth - 300;
+    while (true) {
+        gRend.DrawPos = {debugInfoX, 0};
+    // PRINT REAL TIME
+        gRTC.update_data();
+        print_now(debugInfoX);
+        gRend.crlf(debugInfoX);
+    // PRINT PIT ELAPSED TIME.
     //    gRend.puts("PIT Elapsed: ");
     //    gRend.puts(to_string(gPIT.seconds_since_boot()));
     //    gRend.crlf(debugInfoX);
-    //    // PRINT RTC ELAPSED TIME.
-    //    gRend.puts("RTC Elapsed: ");
-    //    gRend.puts(to_string(gRTC.seconds_since_boot()));
-    //    gRend.crlf(debugInfoX);
-    //    // PRINT HPET ELAPSED TICKS.
+    // PRINT RTC ELAPSED TIME.
+    gRend.puts("RTC Elapsed: ");
+    gRend.puts(to_string(gRTC.seconds_since_boot()));
+    gRend.crlf(debugInfoX);
+    // PRINT HPET ELAPSED TICKS.
     //    gRend.puts("HPET Elapsed: ");
     //    gRend.puts(to_string(gHPET.get_seconds()));
     //    gRend.crlf(debugInfoX);
-    //    // PRINT MEMORY INFO.
-    //    gRend.crlf(debugInfoX);
-    //    print_memory_info();
+    // PRINT MEMORY INFO.
+        gRend.crlf(debugInfoX);
+        print_memory_info();
     //    // UPDATE TOP RIGHT CORNER OF SCREEN.
-    //    gRend.swap({debugInfoX, 0}, {80000, 400});
-    //}
+        gRend.swap({debugInfoX, 0}, {80000, 400});
+    }
 
     // HALT LOOP (KERNEL INACTIVE).
     while (true) {

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -174,12 +174,12 @@ void print_now(u64 xOffset = 0) {
     gRend.crlf(xOffset);
 }
 
-//void test_userland_function() {
-//    for (;;) {
-//        asm volatile ("mov $0, %rax\r\n\t"
-//                      "int $0x80\r\n\t");
-//    }
-//}
+void test_userland_function() {
+    for (;;) {
+        asm volatile ("mov $0, %rax\r\n\t"
+                      "int $0x80\r\n\t");
+    }
+}
 
 // 'userland_function' USED IN 'userswitch.asm' AS EXTERNAL SYMBOL.
 void* userland_function;
@@ -205,7 +205,7 @@ extern "C" void _start(BootInfo* bInfo) {
     /// END GPLv3 LICENSE REQUIREMENT.
 
     // USERLAND SWITCH TESTING
-    //userland_function = (void*)test_userland_function;
+    userland_function = (void*)test_userland_function;
     //jump_to_userland_function();
 
     // FIXME FIXME FIXME
@@ -219,7 +219,6 @@ extern "C" void _start(BootInfo* bInfo) {
     // I'm lovin' it :^) (Plays Maccy's theme).
     constexpr double MACCYS_BPM = 125;
     constexpr double MACCYS_STEP_LENGTH_SECONDS = (60 / MACCYS_BPM) / 4;
-    gPIT.prepare_wait_seconds(MACCYS_STEP_LENGTH_SECONDS);
     gPIT.play_sound(262, MACCYS_STEP_LENGTH_SECONDS); // C4
     gPIT.play_sound(294, MACCYS_STEP_LENGTH_SECONDS); // D4
     gPIT.wait();                                      // Rest

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -118,90 +118,93 @@
  * |
  * `- Add GPLv3 license header to top of every source file (exactly as seen in LICENSE).
  */
-void print_memory_info() {
-    u32 startOffset = gRend.DrawPos.x;
-    gRend.puts("Memory Info:");
-    gRend.crlf(startOffset);
-    gRend.puts("|- Total RAM: ");
-    gRend.puts(to_string(Memory::get_total_ram() / 1024 / 1024));
-    gRend.puts(" MiB (");
-    gRend.puts(to_string(Memory::get_total_ram() / 1024));
-    gRend.puts(" KiB)");
-    gRend.crlf(startOffset);
-    gRend.puts("|- Free RAM: ");
-    gRend.puts(to_string(Memory::get_free_ram() / 1024 / 1024));
-    gRend.puts(" MiB (");
-    gRend.puts(to_string(Memory::get_free_ram() / 1024));
-    gRend.puts(" KiB)");
-    gRend.crlf(startOffset);
-    gRend.puts("`- Used RAM: ");
-    gRend.puts(to_string(Memory::get_used_ram() / 1024 / 1024));
-    gRend.puts(" MiB (");
-    gRend.puts(to_string(Memory::get_used_ram() / 1024));
-    gRend.puts(" KiB)");
-    gRend.crlf(startOffset);
-}
+//void print_memory_info() {
+//    u32 startOffset = gRend.DrawPos.x;
+//    gRend.puts("Memory Info:");
+//    gRend.crlf(startOffset);
+//    gRend.puts("|- Total RAM: ");
+//    gRend.puts(to_string(Memory::get_total_ram() / 1024 / 1024));
+//    gRend.puts(" MiB (");
+//    gRend.puts(to_string(Memory::get_total_ram() / 1024));
+//    gRend.puts(" KiB)");
+//    gRend.crlf(startOffset);
+//    gRend.puts("|- Free RAM: ");
+//    gRend.puts(to_string(Memory::get_free_ram() / 1024 / 1024));
+//    gRend.puts(" MiB (");
+//    gRend.puts(to_string(Memory::get_free_ram() / 1024));
+//    gRend.puts(" KiB)");
+//    gRend.crlf(startOffset);
+//    gRend.puts("`- Used RAM: ");
+//    gRend.puts(to_string(Memory::get_used_ram() / 1024 / 1024));
+//    gRend.puts(" MiB (");
+//    gRend.puts(to_string(Memory::get_used_ram() / 1024));
+//    gRend.puts(" KiB)");
+//    gRend.crlf(startOffset);
+//}
 
-void srl_memory_info() {
-    UART::out("\r\nMemory Info:\r\n|- Total RAM: ");
-    UART::out(to_string(Memory::get_total_ram() / 1024 / 1024));
-    UART::out("MiB (");
-    UART::out(to_string(Memory::get_total_ram() / 1024));
-    UART::out("KiB)\r\n|- Free RAM: ");
-    UART::out(to_string(Memory::get_free_ram() / 1024 / 1024));
-    UART::out(" MiB (");
-    UART::out(to_string(Memory::get_free_ram() / 1024));
-    UART::out(" KiB)\r\n`- Used RAM: ");
-    UART::out(to_string(Memory::get_used_ram() / 1024 / 1024));
-    UART::out(" MiB (");
-    UART::out(to_string(Memory::get_used_ram() / 1024));
-    UART::out(" KiB)\r\n");
-}
+//void srl_memory_info() {
+//    UART::out("\r\nMemory Info:\r\n|- Total RAM: ");
+//    UART::out(to_string(Memory::get_total_ram() / 1024 / 1024));
+//    UART::out("MiB (");
+//    UART::out(to_string(Memory::get_total_ram() / 1024));
+//    UART::out("KiB)\r\n|- Free RAM: ");
+//    UART::out(to_string(Memory::get_free_ram() / 1024 / 1024));
+//    UART::out(" MiB (");
+//    UART::out(to_string(Memory::get_free_ram() / 1024));
+//    UART::out(" KiB)\r\n`- Used RAM: ");
+//    UART::out(to_string(Memory::get_used_ram() / 1024 / 1024));
+//    UART::out(" MiB (");
+//    UART::out(to_string(Memory::get_used_ram() / 1024));
+//    UART::out(" KiB)\r\n");
+//}
 
-void print_now(u64 xOffset = 0) {
-    gRend.puts("Now is ");
-    gRend.puts(to_string(gRTC.Time.hour));
-    gRend.putchar(':');
-    gRend.puts(to_string(gRTC.Time.minute));
-    gRend.putchar(':');
-    gRend.puts(to_string(gRTC.Time.second));
-    gRend.puts(" on ");
-    gRend.puts(to_string(gRTC.Time.year));
-    gRend.putchar('-');
-    gRend.puts(to_string(gRTC.Time.month));
-    gRend.putchar('-');
-    gRend.puts(to_string(gRTC.Time.date));
-    gRend.crlf(xOffset);
-}
+//void print_now(u64 xOffset = 0) {
+//    gRend.puts("Now is ");
+//    gRend.puts(to_string(gRTC.Time.hour));
+//    gRend.putchar(':');
+//    gRend.puts(to_string(gRTC.Time.minute));
+//    gRend.putchar(':');
+//    gRend.puts(to_string(gRTC.Time.second));
+//    gRend.puts(" on ");
+//    gRend.puts(to_string(gRTC.Time.year));
+//    gRend.putchar('-');
+//    gRend.puts(to_string(gRTC.Time.month));
+//    gRend.putchar('-');
+//    gRend.puts(to_string(gRTC.Time.date));
+//    gRend.crlf(xOffset);
+//}
 
-void test_userland_function() {
-    for (;;) {
-        asm volatile ("mov $0, %rax\r\n\t"
-                      "int $0x80\r\n\t");
-    }
-}
+//void test_userland_function() {
+//    for (;;) {
+//        asm volatile ("mov $0, %rax\r\n\t"
+//                      "int $0x80\r\n\t");
+//    }
+//}
 
 // 'userland_function' USED IN 'userswitch.asm' AS EXTERNAL SYMBOL.
 void* userland_function;
 
 extern "C" void _start(BootInfo* bInfo) {
+
+                   (void)         bInfo; 
+
     // The heavy lifting is done within the `kernel_init` function (found in `kUtility.cpp`).
-    kernel_init(bInfo);
-    UART::out("\r\n\033[1;33m!===--- You have now booted into LensorOS ---===!\033[0m\r\n");
-    // Clear + swap screen (ensure known state: blank).
-    gRend.clear(0x00000000);
-    gRend.swap();
-    /// GPLv3 LICENSE REQUIREMENT (interactive terminal must print copyright notice).
-    const char* GPLv3 = "<LensorOS>  Copyright (C) <2022>  <Rylan Lens Kellogg>";
-    // TO SERIAL
-    UART::out(GPLv3);
-    UART::out("\r\n\r\n");
-    // TO SCREEN
-    gRend.BackgroundColor = 0xffffffff;
-    gRend.puts(GPLv3, 0x00000000);
-    gRend.BackgroundColor = 0x00000000;
-    gRend.crlf();
-    gRend.swap({0, 0}, {80000, gRend.Font->PSF1_Header->CharacterSize});
+    //kernel_init(bInfo);
+    //UART::out("\r\n\033[1;33m!===--- You have now booted into LensorOS ---===!\033[0m\r\n");
+    //// Clear + swap screen (ensure known state: blank).
+    //gRend.clear(0x00000000);
+    //gRend.swap();
+    ///// GPLv3 LICENSE REQUIREMENT (interactive terminal must print copyright notice).
+    //const char* GPLv3 = "<LensorOS>  Copyright (C) <2022>  <Rylan Lens Kellogg>";
+    //// TO SERIAL
+    //UART::out(GPLv3);
+    //UART::out("\r\n\r\n");
+    //// TO SCREEN
+    //gRend.BackgroundColor = 0xffffffff;
+    //gRend.puts(GPLv3, 0x00000000);
+    //gRend.BackgroundColor = 0x00000000;
+    //gRend.crlf();
+    //gRend.swap({0, 0}, {80000, gRend.Font->PSF1_Header->CharacterSize});
     /// END GPLv3 LICENSE REQUIREMENT.
 
     // USERLAND SWITCH TESTING
@@ -217,45 +220,45 @@ extern "C" void _start(BootInfo* bInfo) {
     //UART::out("Null de-referenced!\r\n");
 
     // I'm lovin' it :^) (Plays Maccy's theme).
-    constexpr double MACCYS_BPM = 125;
-    constexpr double MACCYS_STEP_LENGTH_SECONDS = (60 / MACCYS_BPM) / 4;
-    gPIT.prepare_wait_seconds(MACCYS_STEP_LENGTH_SECONDS);
-    gPIT.play_sound(262, MACCYS_STEP_LENGTH_SECONDS); // C4
-    gPIT.play_sound(294, MACCYS_STEP_LENGTH_SECONDS); // D4
-    gPIT.wait();                                      // Rest
-    gPIT.play_sound(330, MACCYS_STEP_LENGTH_SECONDS); // E4
-    gPIT.wait();                                      // Rest
-    gPIT.play_sound(440, MACCYS_STEP_LENGTH_SECONDS); // A4
-    gPIT.wait();                                      // Rest
-    gPIT.play_sound(392, MACCYS_STEP_LENGTH_SECONDS); // G4
+    //constexpr double MACCYS_BPM = 125;
+    //constexpr double MACCYS_STEP_LENGTH_SECONDS = (60 / MACCYS_BPM) / 4;
+    //gPIT.prepare_wait_seconds(MACCYS_STEP_LENGTH_SECONDS);
+    //gPIT.play_sound(262, MACCYS_STEP_LENGTH_SECONDS); // C4
+    //gPIT.play_sound(294, MACCYS_STEP_LENGTH_SECONDS); // D4
+    //gPIT.wait();                                      // Rest
+    //gPIT.play_sound(330, MACCYS_STEP_LENGTH_SECONDS); // E4
+    //gPIT.wait();                                      // Rest
+    //gPIT.play_sound(440, MACCYS_STEP_LENGTH_SECONDS); // A4
+    //gPIT.wait();                                      // Rest
+    //gPIT.play_sound(392, MACCYS_STEP_LENGTH_SECONDS); // G4
 
     // Start keyboard input at draw position, not origin.
-    Keyboard::gText.set_cursor_from_pixel_position(gRend.DrawPos);
-    u32 debugInfoX = gRend.Target->PixelWidth - 300;
-    while (true) {
-        gRend.DrawPos = {debugInfoX, 0};
-        // PRINT REAL TIME
-        gRTC.update_data();
-        print_now(debugInfoX);
-        gRend.crlf(debugInfoX);
-        // PRINT PIT ELAPSED TIME.
-        gRend.puts("PIT Elapsed: ");
-        gRend.puts(to_string(gPIT.seconds_since_boot()));
-        gRend.crlf(debugInfoX);
-        // PRINT RTC ELAPSED TIME.
-        gRend.puts("RTC Elapsed: ");
-        gRend.puts(to_string(gRTC.seconds_since_boot()));
-        gRend.crlf(debugInfoX);
-        // PRINT HPET ELAPSED TICKS.
-        gRend.puts("HPET Elapsed: ");
-        gRend.puts(to_string(gHPET.get_seconds()));
-        gRend.crlf(debugInfoX);
-        // PRINT MEMORY INFO.
-        gRend.crlf(debugInfoX);
-        print_memory_info();
-        // UPDATE TOP RIGHT CORNER OF SCREEN.
-        gRend.swap({debugInfoX, 0}, {80000, 400});
-    }
+    //Keyboard::gText.set_cursor_from_pixel_position(gRend.DrawPos);
+    //u32 debugInfoX = gRend.Target->PixelWidth - 300;
+    //while (true) {
+    //    gRend.DrawPos = {debugInfoX, 0};
+    //    // PRINT REAL TIME
+    //    gRTC.update_data();
+    //    print_now(debugInfoX);
+    //    gRend.crlf(debugInfoX);
+    //    // PRINT PIT ELAPSED TIME.
+    //    gRend.puts("PIT Elapsed: ");
+    //    gRend.puts(to_string(gPIT.seconds_since_boot()));
+    //    gRend.crlf(debugInfoX);
+    //    // PRINT RTC ELAPSED TIME.
+    //    gRend.puts("RTC Elapsed: ");
+    //    gRend.puts(to_string(gRTC.seconds_since_boot()));
+    //    gRend.crlf(debugInfoX);
+    //    // PRINT HPET ELAPSED TICKS.
+    //    gRend.puts("HPET Elapsed: ");
+    //    gRend.puts(to_string(gHPET.get_seconds()));
+    //    gRend.crlf(debugInfoX);
+    //    // PRINT MEMORY INFO.
+    //    gRend.crlf(debugInfoX);
+    //    print_memory_info();
+    //    // UPDATE TOP RIGHT CORNER OF SCREEN.
+    //    gRend.swap({debugInfoX, 0}, {80000, 400});
+    //}
 
     // HALT LOOP (KERNEL INACTIVE).
     while (true) {

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -234,26 +234,26 @@ extern "C" void _start(BootInfo* bInfo) {
     u32 debugInfoX = gRend.Target->PixelWidth - 300;
     while (true) {
         gRend.DrawPos = {debugInfoX, 0};
-    // PRINT REAL TIME
+        // PRINT REAL TIME
         gRTC.update_data();
         print_now(debugInfoX);
         gRend.crlf(debugInfoX);
-    // PRINT PIT ELAPSED TIME.
-    //    gRend.puts("PIT Elapsed: ");
-    //    gRend.puts(to_string(gPIT.seconds_since_boot()));
-    //    gRend.crlf(debugInfoX);
-    // PRINT RTC ELAPSED TIME.
-    gRend.puts("RTC Elapsed: ");
-    gRend.puts(to_string(gRTC.seconds_since_boot()));
-    gRend.crlf(debugInfoX);
-    // PRINT HPET ELAPSED TICKS.
-    //    gRend.puts("HPET Elapsed: ");
-    //    gRend.puts(to_string(gHPET.get_seconds()));
-    //    gRend.crlf(debugInfoX);
-    // PRINT MEMORY INFO.
+        // PRINT PIT ELAPSED TIME.
+        //    gRend.puts("PIT Elapsed: ");
+        //    gRend.puts(to_string(gPIT.seconds_since_boot()));
+        //    gRend.crlf(debugInfoX);
+        // PRINT RTC ELAPSED TIME.
+        gRend.puts("RTC Elapsed: ");
+        gRend.puts(to_string(gRTC.seconds_since_boot()));
+        gRend.crlf(debugInfoX);
+        // PRINT HPET ELAPSED TICKS.
+        gRend.puts("HPET Elapsed: ");
+        gRend.puts(to_string(gHPET.get_seconds()));
+        gRend.crlf(debugInfoX);
+        // PRINT MEMORY INFO.
         gRend.crlf(debugInfoX);
         print_memory_info();
-    //    // UPDATE TOP RIGHT CORNER OF SCREEN.
+        // UPDATE TOP RIGHT CORNER OF SCREEN.
         gRend.swap({debugInfoX, 0}, {80000, 400});
     }
 

--- a/kernel/src/memory.cpp
+++ b/kernel/src/memory.cpp
@@ -40,6 +40,8 @@ void memcpy(void* src, void* dest, u64 numBytes) {
 }
 
 void volatile_read(const volatile void* ptr, volatile void* out, u64 length) {
+    if (ptr == nullptr || out == nullptr || length == 0)
+        return;
     // FIXME: Are memory barries necessary for the memcpy call?
     if (length == 1)
         *(u8*)out = *(volatile u8*)ptr;
@@ -53,6 +55,8 @@ void volatile_read(const volatile void* ptr, volatile void* out, u64 length) {
 }
 
 void volatile_write(void* data, volatile void* ptr, u64 length) {
+    if (data == nullptr || ptr == nullptr || length == 0)
+        return;
     // FIXME: Are memory barriers necessary for the memcpy call?
     if (length == 1)
         *(volatile u8*)ptr = *(u8*)data;

--- a/kernel/src/memory/heap.cpp
+++ b/kernel/src/memory/heap.cpp
@@ -89,7 +89,7 @@ void init_heap() {
     UART::out(to_hexstring<void*>(sHeapEnd));
     UART::out("\r\n  Size: ");
     UART::out(numBytes);
-    UART::out("\r\n");
+    UART::out("\r\n\r\n");
 }
 
 void expand_heap(u64 numBytes) {

--- a/kernel/src/memory/physical_memory_manager.cpp
+++ b/kernel/src/memory/physical_memory_manager.cpp
@@ -157,7 +157,7 @@ namespace Memory {
         UART::out(" bytes)\r\n");
         UART::out("    Lost to Page Alignment: ");
         UART::out(deadSpace);
-        UART::out(" bytes\r\n");
+        UART::out(" bytes\r\n\r\n");
     }
 
     void init_physical_efi(EFI_MEMORY_DESCRIPTOR* map, u64 size, u64 entrySize) {
@@ -209,13 +209,12 @@ namespace Memory {
     }
 
     void print_debug() {
-        UART::out("Memory Manager Debug Dump:");
-        UART::out("\r\n  Total Memory: ");
+        UART::out("Memory Manager Debug Dump:\r\n  Total Memory: ");
         UART::out(to_string(TotalPages * PAGE_SIZE / 1024 / 1024));
         UART::out("MiB\r\n  Free Memory: ");
         UART::out(to_string(TotalFreePages * PAGE_SIZE / 1024 / 1024));
         UART::out("MiB\r\n  Used Memory: ");
         UART::out(to_string(TotalUsedPages * PAGE_SIZE / 1024 / 1024));
-        UART::out("MiB\r\n");
+        UART::out("MiB\r\n\r\n");
     }
 }

--- a/kernel/src/pit.cpp
+++ b/kernel/src/pit.cpp
@@ -24,7 +24,7 @@ void PIT::prepare_wait_seconds(double duration) {
 void PIT::wait() {
     u64 tickToWaitTo = Ticks + TicksToWait;
     while (Ticks < tickToWaitTo)
-        asm volatile ("nop");
+        asm volatile ("hlt");
 }
 
 void PIT::start_speaker() {

--- a/kernel/src/pit.cpp
+++ b/kernel/src/pit.cpp
@@ -6,6 +6,7 @@
 #include "uart.h"
 
 PIT gPIT;
+void pit_tick() { gPIT.tick(); }
 
 PIT::PIT() {
     configure_channel(Channel::Zero, Access::HighAndLow, Mode::RateGenerator, PIT_FREQUENCY);

--- a/kernel/src/pit.h
+++ b/kernel/src/pit.h
@@ -5,7 +5,7 @@
 #include "io.h"
 
 #define PIT_MAX_FREQ 1193180
-#ifdef QEMU
+#if defined QEMU || defined VBOX
 #define PIT_DIVISOR 59659
 #else
 #define PIT_DIVISOR 1193

--- a/kernel/src/pit.h
+++ b/kernel/src/pit.h
@@ -97,7 +97,7 @@ public:
 
 private:
     /// Incremented by IRQ0 interrupt handler.
-    u64 Ticks { 0 };
+    volatile u64 Ticks { 0 };
     /* `wait()` stops spinning as soon `Ticks` reaches
      *   offset from `Ticks` at beginning of spinning.
      */
@@ -113,5 +113,8 @@ private:
 };
 
 extern PIT gPIT;
+
+// This work-around/hack is due to needing a function pointer 
+void pit_tick();
 
 #endif /* LENSOR_OS_PIT_H */

--- a/kernel/src/rtc.h
+++ b/kernel/src/rtc.h
@@ -96,13 +96,13 @@ struct RTCData {
     }
 };
 
-
-#ifdef QEMU
+#if defined QEMU || defined VBOX
 #define RTC_PERIODIC_RATE 10
 #else
 #define RTC_PERIODIC_RATE 6
-#endif
+#endif /* QEMU || VBOX */
 #define RTC_PERIODIC_HERTZ (32768 >> (RTC_PERIODIC_RATE - 1))
+
 class RTC {
 public:
     RTCData Time;

--- a/kernel/src/rtc.h
+++ b/kernel/src/rtc.h
@@ -73,14 +73,14 @@ Status Register `D`:
 #define CENTURY_REGISTER 0x00
 
 struct RTCData {
-    u8  second  {0};
-    u8  minute  {0};
-    u8  hour    {0};
-    u8  weekday {0};
-    u8  date    {0};
-    u8  month   {0};
-    u32 year    {0};
-    u8  century {0};
+    u8  second  { 0 };
+    u8  minute  { 0 };
+    u8  hour    { 0 };
+    u8  weekday { 0 };
+    u8  date    { 0 };
+    u8  month   { 0 };
+    u32 year    { 0 };
+    u8  century { 0 };
 
     RTCData() {}
 
@@ -106,7 +106,7 @@ struct RTCData {
 class RTC {
 public:
     RTCData Time;
-    u64 Ticks {0};
+    u64 Ticks { 0 };
 
     RTC() {
         update_data();

--- a/kernel/src/scheduler.asm
+++ b/kernel/src/scheduler.asm
@@ -13,6 +13,7 @@ do_swapgs:
 skip_swap:
     ret
 
+    GLOBAL irq0_handler
 irq0_handler:
     push rbp
     mov rbp, rsp
@@ -49,8 +50,8 @@ irq0_handler:
     mov rdi, rsp
     call [scheduler_switch_func]
 ;;; END INTERRUPT
-    mov ax, 0x20                ; 0x20 = PIC_EOI
-    out 0x20, ax                ; 0x20 = PIC1_COMMAND port
+    mov al, 0x20                ; 0x20 = PIC_EOI
+    out 0x20, al                ; 0x20 = PIC1_COMMAND port
 ;;; RESTORE CPU STATE FROM STACK
     add rsp, 8                  ; Eat `rsp` off of stack.
     pop rbx
@@ -73,5 +74,3 @@ irq0_handler:
     call do_swapgs
     pop rbp
     iretq
-
-GLOBAL irq0_handler

--- a/kernel/src/scheduler.asm
+++ b/kernel/src/scheduler.asm
@@ -49,8 +49,8 @@ irq0_handler:
     mov rdi, rsp
     call [scheduler_switch_func]
 ;;; END INTERRUPT
-    mov ax, 0x20
-    out 0x20, ax
+    mov ax, 0x20                ; 0x20 = PIC_EOI
+    out 0x20, ax                ; 0x20 = PIC1_COMMAND port
 ;;; RESTORE CPU STATE FROM STACK
     add rsp, 8                  ; Eat `rsp` off of stack.
     pop rbx

--- a/kernel/src/scheduler.cpp
+++ b/kernel/src/scheduler.cpp
@@ -35,7 +35,7 @@ void Scheduler::switch_process(CPUState* cpu) {
     Memory::flush_page_map(CurrentProcess->CR3);
 }
 
-void Scheduler::initialize(Memory::PageTable* bootPageMap) {
+void Scheduler::initialize() {
     ProcessQueue = &StartupProcess;
     CurrentProcess = &StartupProcess;
     // IRQ handler in assembly needs to increment PIT ticks counter.
@@ -43,7 +43,7 @@ void Scheduler::initialize(Memory::PageTable* bootPageMap) {
     // IRQ handler in assembly needs to call a function to switch process.
     scheduler_switch_func = (void*)switch_process;
     // Setup start process as current executing code.
-    StartupProcess.CR3 = bootPageMap;
+    StartupProcess.CR3 = Memory::get_active_page_map();
     StartupProcess.Next = nullptr;
     // Install IRQ0 handler found in `scheduler.asm` (over-write default system timer handler).
     gIDT.install_handler((u64)irq0_handler, PIC_IRQ0);

--- a/kernel/src/scheduler.cpp
+++ b/kernel/src/scheduler.cpp
@@ -37,7 +37,6 @@ void Scheduler::switch_process(CPUState* cpu) {
 
 void Scheduler::initialize() {
     ProcessQueue = &StartupProcess;
-
     CurrentProcess = &StartupProcess;
     // IRQ handler in assembly needs to increment PIT ticks counter.
     timer_tick = &pit_tick;
@@ -47,7 +46,5 @@ void Scheduler::initialize() {
     StartupProcess.CR3 = Memory::get_active_page_map();
     StartupProcess.Next = nullptr;
     // Install IRQ0 handler found in `scheduler.asm` (over-write default system timer handler).
-
-    // FIXME: SOMETHING IN THIS HANDLER DOESN'T WORK ON VIRTUAL BOX :^<
-    gIDT.install_handler((u64)&irq0_handler, PIC_IRQ0);
+    gIDT.install_handler((u64)irq0_handler, PIC_IRQ0);
 }

--- a/kernel/src/scheduler.cpp
+++ b/kernel/src/scheduler.cpp
@@ -10,7 +10,7 @@
 
 // External symbols for `scheduler.asm`
 void* scheduler_switch_func;
-u64* timer_ticks;
+void(*timer_tick)();
 
 KernelProcess StartupProcess;
 
@@ -37,14 +37,17 @@ void Scheduler::switch_process(CPUState* cpu) {
 
 void Scheduler::initialize() {
     ProcessQueue = &StartupProcess;
+
     CurrentProcess = &StartupProcess;
     // IRQ handler in assembly needs to increment PIT ticks counter.
-    timer_ticks = &gPIT.Ticks;
+    timer_tick = &pit_tick;
     // IRQ handler in assembly needs to call a function to switch process.
     scheduler_switch_func = (void*)switch_process;
     // Setup start process as current executing code.
     StartupProcess.CR3 = Memory::get_active_page_map();
     StartupProcess.Next = nullptr;
     // Install IRQ0 handler found in `scheduler.asm` (over-write default system timer handler).
-    gIDT.install_handler((u64)irq0_handler, PIC_IRQ0);
+
+    // FIXME: SOMETHING IN THIS HANDLER DOESN'T WORK ON VIRTUAL BOX :^<
+    gIDT.install_handler((u64)&irq0_handler, PIC_IRQ0);
 }

--- a/kernel/src/scheduler.h
+++ b/kernel/src/scheduler.h
@@ -61,7 +61,7 @@ class Scheduler {
      * `- load_elf() that will read an elf executable and add it to process list.
      */
 public:
-    static void initialize(Memory::PageTable*);
+    static void initialize();
     /* Switch to the next available task.
      * | Called by IRQ0 Handler (System Timer Interrupt).
      * |- Copy registers saved from IRQ0 to current process.

--- a/kernel/src/scheduler.h
+++ b/kernel/src/scheduler.h
@@ -4,15 +4,16 @@
 #include "integers.h"
 #include "interrupts/interrupts.h"
 
-extern void* scheduler_switch_task;
-extern u64* timer_ticks;
-
-/// Interrupt handler function found in `scheduler.asm`
-extern "C" void irq0_handler();
-
 namespace Memory {
     class PageTable;
 }
+
+struct CPUState;
+/// External symbols for 'scheduler.asm', defined in `scheduler.cpp`
+extern void(*scheduler_switch_task)(CPUState*);
+extern void(*timer_tick)();
+/// Interrupt handler function found in `scheduler.asm`
+extern "C" void irq0_handler();
 
 /* THE KERNEL PROCESS SCHEDULER
  * | Hijack the System Timer Interrupt to switch processes, if needed.

--- a/kernel/src/uart.cpp
+++ b/kernel/src/uart.cpp
@@ -63,14 +63,17 @@ namespace UART {
                 chip = Chip::_16450;
             else chip = Chip::_8250;
         }
-        // Loop-back test.
-        //out8(MODEM_CONTROL_PORT(COM1), 0b00011111);
-        //u8 test_byte = 0xae;
-        //out8(COM1, test_byte);
-        //if (in8(COM1) != test_byte) {
-        //    Initialized = false;
-        //    return;
-        //}
+
+#ifndef VBOX
+        // Complete a loop-back test to verify all is well.
+        out8(MODEM_CONTROL_PORT(COM1), 0b00011111);
+        u8 test_byte = 0xae;
+        out8(COM1, test_byte);
+        if (in8(COM1) != test_byte) {
+           Initialized = false;
+           return;
+        }
+#endif
 
         // Disable loop-back, set 'Data Terminal Ready' and 'Request to Send'.
         out8(MODEM_CONTROL_PORT(COM1), 0b00001111);

--- a/kernel/src/uart.cpp
+++ b/kernel/src/uart.cpp
@@ -64,17 +64,21 @@ namespace UART {
             else chip = Chip::_8250;
         }
         // Loop-back test.
-        out8(MODEM_CONTROL_PORT(COM1), 0b00011111);
-        u8 test_byte = 0xae;
-        out8(COM1, test_byte);
-        if (in8(COM1) != test_byte) {
-            Initialized = false;
-            return;
-        }
+        //out8(MODEM_CONTROL_PORT(COM1), 0b00011111);
+        //u8 test_byte = 0xae;
+        //out8(COM1, test_byte);
+        //if (in8(COM1) != test_byte) {
+        //    Initialized = false;
+        //    return;
+        //}
 
         // Disable loop-back, set 'Data Terminal Ready' and 'Request to Send'.
         out8(MODEM_CONTROL_PORT(COM1), 0b00001111);
 
+        // Enable IRQs for data available interrupts.
+        out8(INTERRUPT_PORT(COM1), INTERRUPT_PORT_DATA_AVAILABLE);
+        Initialized = true;
+        
         // First serial messages output from the OS.
         out("\r\n\r\nWelcome to \033[5;1;33mLensorOS\033[0m\r\n\r\n");
         out("[UART]: Initialized driver\r\n  Detected '");
@@ -82,13 +86,9 @@ namespace UART {
         out("' chip\r\n");
 
 #ifdef COM1_INPUT_DEBUG
-        writestr("[UART]: Data recieved over COM1 will be looped back in the following format:\r\n");
-        writestr("  \"[UART]: COM1 INPUT -> <hexadecimal> <integer> <raw byte>\"");
+        out("[UART]: Data recieved over COM1 will be looped back in the following format:\r\n");
+        out("  \"[UART]: COM1 INPUT -> <hexadecimal> <integer> <raw byte>\"");
 #endif
-
-        // Enable IRQs for data available interrupts.
-        out8(INTERRUPT_PORT(COM1), INTERRUPT_PORT_DATA_AVAILABLE);
-        Initialized = true;
     }
 
     u8 read() {


### PR DESCRIPTION
About a month into development, I decided to test LensorOS on VirtualBox. It didn't work at all, with a #GP fault happening early in the kernel initialization. I spent a few hours trying to get it to work, but left frustrated and drained of motivation. I decided it wasn't important and as long as it ran in QEMU I should just keep going. I'm glad I did this, as I made a lot of progress since then, however I am also unhappy that LensorOS didn't work on VirtualBox, a platform that should have no problem booting UEFI OSes.

Today, I'm proud to say LensorOS can now be booted from a virtual machine in VirtualBox!!

To mend this fence between QEMU and VBOX, I first figured out a way to more easily build and test LensorOS for VirtualBox; VBOX doesn't support raw format storage devices, so further processing to the image file was needed. The helper script `mkiso.sh` runs the old `mkimg.sh`, then creates a bootable ISO-9660 filesystem within `LensorOS.iso`, which can then be attached to a VBOX virtual machine quite easily. This all utilizes the GNU `xorriso` tool.

Once it was easy to test LensorOS on VBOX, I was off to the races. I disabled every single line of executing code in the kernel, and slowly re-introduced the code until problems arose within VirtualBox (or QEMU). As the problems cropped up, I did my best to fix them, testing on both QEMU and VBOX.

At this point, all of the code has been re-enabled (un-commented), and the functionality matches that of the master branch very closely, except for the changes that have been made to accommodate running in VirtualBox.